### PR TITLE
Accept target-page id-parameter in tprek format

### DIFF
--- a/src/common/utils/api/api.test.ts
+++ b/src/common/utils/api/api.test.ts
@@ -14,7 +14,7 @@ describe('apiRequest - getTarget', () => {
 
     mockedAxios.request.mockResolvedValue({ data: mockTarget });
 
-    const response = await api.getTarget('8100');
+    const response = await api.getTarget('tprek:8100');
 
     expect(mockedAxios.request).toHaveBeenCalledTimes(1);
 

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -54,5 +54,5 @@ export interface Target {
 
 export default {
   getTarget: (id: string): Promise<Target> =>
-    apiGet<Target>({ path: `${TARGET_BASE_PATH}/tprek:${id}` }),
+    apiGet<Target>({ path: `${TARGET_BASE_PATH}/${id}` }),
 };


### PR DESCRIPTION
This can be tested by starting application with ```API_URL=https://hauki-test.oc.hel.ninja yarn start``` and visiting http://localhost:3000/target/tprek:8100