### PR TITLE
Hauki 162 ui tweaking

### DIFF
--- a/src/components/collapse/Collapse.scss
+++ b/src/components/collapse/Collapse.scss
@@ -16,6 +16,12 @@
   width: 100%;
 }
 
+.collapse-title {
+  color: var(--color-coat-of-arms-blue);
+  font-size: var(--fontsize-heading-m);
+  margin-bottom: var(--spacing-s);
+}
+
 .collapse-button-icon {
   color: var(--hauki-content-text-color);
 }

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -64,7 +64,7 @@ export default function ({
   return (
     <div className="collapse">
       <div className="collapse-header">
-        <h2>
+        <h2 className="collapse-title">
           <CollapseButton
             collapseContentId={collapseContentId}
             isOpen={isOpenState}

--- a/src/components/footer/HaukiFooter.scss
+++ b/src/components/footer/HaukiFooter.scss
@@ -4,5 +4,5 @@
 }
 
 .hauki-koros pattern {
-  fill: var(--primary-color);
+  fill: var(--hauki-footer-background-color);
 }

--- a/src/components/main/Main.scss
+++ b/src/components/main/Main.scss
@@ -17,10 +17,6 @@
   width: 100%;
 }
 
-.main-container h2 {
-  color: var(--color-coat-of-arms-blue);
-}
-
 .section {
   & + & {
     margin-top: $spacing-5-xl;

--- a/src/components/main/Main.scss
+++ b/src/components/main/Main.scss
@@ -11,6 +11,7 @@
 
 .main-container {
   box-sizing: border-box;
+  line-height: var(--lineheight-l);
   margin: 0 auto;
   padding: $spacing-s;
   width: 100%;

--- a/src/target/page/TargetPage.scss
+++ b/src/target/page/TargetPage.scss
@@ -12,3 +12,7 @@
   display: inline-block;
   font-style: normal;
 }
+
+.target-description-text {
+  white-space: pre;
+}

--- a/src/target/page/TargetPage.scss
+++ b/src/target/page/TargetPage.scss
@@ -1,5 +1,11 @@
 .target-details-section {
-  margin-top: var(--spacing-layout-l);
+  margin-top: var(--spacing-layout-m);
+}
+
+.target-info-title {
+  font-size: var(--fontsize-heading-l);
+  margin-top: 0;
+  margin-bottom: var(--spacing-xs);
 }
 
 .target-info-address {

--- a/src/target/page/TargetPage.tsx
+++ b/src/target/page/TargetPage.tsx
@@ -71,7 +71,7 @@ export default function TargetPage({ id }: { id: string }): JSX.Element {
     <>
       <TargetInfo target={target} />
       <TargetDetailsSection id="target-description" title="Perustiedot">
-        <p>
+        <p className="target-description-text">
           {hasText(target?.description)
             ? target?.description
             : 'Toimipisteellä ei ole kuvausta.'}

--- a/src/target/page/TargetPage.tsx
+++ b/src/target/page/TargetPage.tsx
@@ -13,7 +13,11 @@ const TargetInfo = ({ target }: { target?: Target }): JSX.Element => (
     {hasText(target?.address) && (
       <div>
         <span>Osoite: </span>
-        <address className="target-info-address">{target?.address}</address>
+        <address className="target-info-address">
+          {hasText(target?.address)
+            ? target?.address
+            : 'Toimipisteellä ei ole nimeä.'}
+        </address>
       </div>
     )}
   </>

--- a/src/target/page/TargetPage.tsx
+++ b/src/target/page/TargetPage.tsx
@@ -9,7 +9,7 @@ const hasText = (str: string | null | undefined): boolean =>
 
 const TargetInfo = ({ target }: { target?: Target }): JSX.Element => (
   <>
-    <h1>{target?.name}</h1>
+    <h1 className="target-info-title">{target?.name}</h1>
     {hasText(target?.address) && (
       <div>
         <span>Osoite: </span>

--- a/src/variables.css
+++ b/src/variables.css
@@ -3,8 +3,9 @@
 :root {
   --primary-color: var(--color-coat-of-arms-blue);
   --hauki-content-text-color: var(--color-black-90);
-  --hauki-content-background-color: #fafafa;
+  --hauki-content-background-color: #fafafb;
   --hauki-content-border-color: #c4c4c4;
+  --hauki-footer-background-color: var(--color-coat-of-arms-blue-light-20);
 }
 
 :root .navigation-header {


### PR DESCRIPTION
- Fix main's and footer's background-colors
- Set main's content line-height and adjust spacings. Fixes error notification icon-alignment and improves target's description's readability
- Preserve target's description's line-break-formatting to show lists in text correctly

![Näyttökuva 2020-10-8 kello 15 18 06](https://user-images.githubusercontent.com/1610860/95468168-e8be8600-0986-11eb-80b7-6f077f50a203.png)
