### PR TITLE
For consideration: separate test & build stages in pipeline

### DIFF
--- a/azure/master-to-test.pipeline.yml
+++ b/azure/master-to-test.pipeline.yml
@@ -18,57 +18,62 @@ pool:
 
 stages:
 - stage: Tests
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '12.x'
-    displayName: 'Install Node.js'
+  jobs:
+  - job: Tests
+    steps:
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '12.x'
+      displayName: 'Install Node.js'
 
-  - script: |
-      yarn install
-    displayName: 'Yarn install'
+    - script: |
+        yarn install
+      displayName: 'Yarn install'
 
-  - script: |
-      yarn lint
-    displayName: 'Yarn lint'
+    - script: |
+        yarn lint
+      displayName: 'Yarn lint'
 
-  - script: |
-      CI=true yarn test
-    displayName: 'Yarn run tests'
+    - script: |
+        CI=true yarn test
+      displayName: 'Yarn run tests'
 
-  - script: |
-      CI=true yarn test-cypress-headless
-    displayName: 'Yarn run cypress (e2e) tests'
+    - script: |
+        CI=true yarn test-cypress-headless
+      displayName: 'Yarn run cypress (e2e) tests'
 
 - stage: Build_test
-  displayName: Build image & run E2E tests
-  steps:
-  - task: Docker@2
-    displayName: Build and push Hauki admin ui image to docker hub
-    inputs:
-      containerRegistry: Docker hub upload-hauki-admin-ui
-      repository: 'helsinki/$(imageName)'
-      command: buildAndPush
-      tags: |
-        latest
-        $(gitCommitHash)
-      Dockerfile: Dockerfile
+  jobs:
+  - job: Build
+    displayName: Build image & run E2E tests
+    steps:
+    - task: Docker@2
+      displayName: Build and push Hauki admin ui image to docker hub
+      inputs:
+        containerRegistry: Docker hub upload-hauki-admin-ui
+        repository: 'helsinki/$(imageName)'
+        command: buildAndPush
+        tags: |
+          latest
+          $(gitCommitHash)
+        Dockerfile: Dockerfile
 
-  - task: oc-cmd@2
-    displayName: Deploy image to openshift, add OC tag to latest image
-    inputs:
-      openshiftService: Azure OpenShift-hauki-admin-ui
-      cmd: 'tag docker.io/helsinki/hauki-admin-ui:$(gitCommitHash) hauki-admin-ui:latest'
+    - task: oc-cmd@2
+      displayName: Deploy image to openshift, add OC tag to latest image
+      inputs:
+        openshiftService: Azure OpenShift-hauki-admin-ui
+        cmd: 'tag docker.io/helsinki/hauki-admin-ui:$(gitCommitHash) hauki-admin-ui:latest'
+  - job: E2E test
+    steps:
+    - task: Bash@3
+      displayName: Wait for deploy to finish
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Write your commands here
 
-  - task: Bash@3
-    displayName: Wait for deploy to finish
-    inputs:
-      targetType: 'inline'
-      script: |
-        # Write your commands here
+          sleep 50
 
-        sleep 50
-
-  - script: |
-      CI=true yarn test-cypress-test-env
-    displayName: 'Yarn run cypress (e2e) tests against test environment'
+    - script: |
+        CI=true yarn test-cypress-test-env
+      displayName: 'Yarn run cypress (e2e) tests against test environment'

--- a/azure/master-to-test.pipeline.yml
+++ b/azure/master-to-test.pipeline.yml
@@ -63,9 +63,6 @@ stages:
       inputs:
         openshiftService: Azure OpenShift-hauki-admin-ui
         cmd: 'tag docker.io/helsinki/hauki-admin-ui:$(gitCommitHash) hauki-admin-ui:latest'
-  - job: E2E_test
-    displayName: Run E2E tests
-    steps:
     - task: Bash@3
       displayName: Wait for deploy to finish
       inputs:

--- a/azure/master-to-test.pipeline.yml
+++ b/azure/master-to-test.pipeline.yml
@@ -16,54 +16,59 @@ variables:
 pool:
   vmImage: 'ubuntu-latest'
 
-steps:
-- task: NodeTool@0
-  inputs:
-    versionSpec: '12.x'
-  displayName: 'Install Node.js'
+stages:<
+- stage: Tests
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '12.x'
+    displayName: 'Install Node.js'
 
-- script: |
-    yarn install
-  displayName: 'Yarn install'
+  - script: |
+      yarn install
+    displayName: 'Yarn install'
 
-- script: |
-    yarn lint
-  displayName: 'Yarn lint'
+  - script: |
+      yarn lint
+    displayName: 'Yarn lint'
 
-- script: |
-    CI=true yarn test
-  displayName: 'Yarn run tests'
+  - script: |
+      CI=true yarn test
+    displayName: 'Yarn run tests'
 
-- script: |
-    CI=true yarn test-cypress-headless
-  displayName: 'Yarn run cypress (e2e) tests'
+  - script: |
+      CI=true yarn test-cypress-headless
+    displayName: 'Yarn run cypress (e2e) tests'
 
-- task: Docker@2
-  displayName: Build and push Hauki admin ui image to docker hub
-  inputs:
-    containerRegistry: Docker hub upload-hauki-admin-ui
-    repository: 'helsinki/$(imageName)'
-    command: buildAndPush
-    tags: |
-      latest
-      $(gitCommitHash)
-    Dockerfile: Dockerfile
+- stage: Build_test
+  displayName: Build image & run E2E tests
+  steps:
+  - task: Docker@2
+    displayName: Build and push Hauki admin ui image to docker hub
+    inputs:
+      containerRegistry: Docker hub upload-hauki-admin-ui
+      repository: 'helsinki/$(imageName)'
+      command: buildAndPush
+      tags: |
+        latest
+        $(gitCommitHash)
+      Dockerfile: Dockerfile
 
-- task: oc-cmd@2
-  displayName: Deploy image to openshift, add OC tag to latest image
-  inputs:
-    openshiftService: Azure OpenShift-hauki-admin-ui
-    cmd: 'tag docker.io/helsinki/hauki-admin-ui:$(gitCommitHash) hauki-admin-ui:latest'
+  - task: oc-cmd@2
+    displayName: Deploy image to openshift, add OC tag to latest image
+    inputs:
+      openshiftService: Azure OpenShift-hauki-admin-ui
+      cmd: 'tag docker.io/helsinki/hauki-admin-ui:$(gitCommitHash) hauki-admin-ui:latest'
 
-- task: Bash@3
-  displayName: Wait for deploy to finish
-  inputs:
-    targetType: 'inline'
-    script: |
-      # Write your commands here
+  - task: Bash@3
+    displayName: Wait for deploy to finish
+    inputs:
+      targetType: 'inline'
+      script: |
+        # Write your commands here
 
-      sleep 50
+        sleep 50
 
-- script: |
-    CI=true yarn test-cypress-test-env
-  displayName: 'Yarn run cypress (e2e) tests against test environment'
+  - script: |
+      CI=true yarn test-cypress-test-env
+    displayName: 'Yarn run cypress (e2e) tests against test environment'

--- a/azure/master-to-test.pipeline.yml
+++ b/azure/master-to-test.pipeline.yml
@@ -63,7 +63,7 @@ stages:
       inputs:
         openshiftService: Azure OpenShift-hauki-admin-ui
         cmd: 'tag docker.io/helsinki/hauki-admin-ui:$(gitCommitHash) hauki-admin-ui:latest'
-  - job: E2E-test
+  - job: E2E_test
     displayName: Run E2E tests
     steps:
     - task: Bash@3

--- a/azure/master-to-test.pipeline.yml
+++ b/azure/master-to-test.pipeline.yml
@@ -63,7 +63,8 @@ stages:
       inputs:
         openshiftService: Azure OpenShift-hauki-admin-ui
         cmd: 'tag docker.io/helsinki/hauki-admin-ui:$(gitCommitHash) hauki-admin-ui:latest'
-  - job: E2E test
+  - job: E2E-test
+    displayName: Run E2E tests
     steps:
     - task: Bash@3
       displayName: Wait for deploy to finish

--- a/azure/master-to-test.pipeline.yml
+++ b/azure/master-to-test.pipeline.yml
@@ -16,7 +16,7 @@ variables:
 pool:
   vmImage: 'ubuntu-latest'
 
-stages:<
+stages:
 - stage: Tests
   steps:
   - task: NodeTool@0


### PR DESCRIPTION
This is more of a proof of concept (E2E tests will probably not work).

Tests are now run in first stage and image build in second stage. This ensures that anything changed durings tests does not affect the builds. Previously the builds were dependent on things done in tests?