### PR TITLE
Force line-breaking of description if needed, otherwise preserve forma…

### DIFF
--- a/src/target/page/TargetPage.scss
+++ b/src/target/page/TargetPage.scss
@@ -14,5 +14,5 @@
 }
 
 .target-description-text {
-  white-space: pre;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
…tting


Before:
<img width="1501" alt="Näyttökuva 2020-10-20 kello 14 10 51" src="https://user-images.githubusercontent.com/1610860/96579054-de817d80-12de-11eb-9fdd-eda630a9b9ec.png">

After:
<img width="1476" alt="Näyttökuva 2020-10-20 kello 14 11 04" src="https://user-images.githubusercontent.com/1610860/96579049-dd505080-12de-11eb-8990-ecddf29533bf.png">

After lists (do not change): 
<img width="1490" alt="Näyttökuva 2020-10-20 kello 14 11 15" src="https://user-images.githubusercontent.com/1610860/96579041-da556000-12de-11eb-8206-c44e6808c974.png">

