### PR TITLE
Hauki 222 loading indicator

### DIFF
--- a/src/resource/page/ResourcePage.tsx
+++ b/src/resource/page/ResourcePage.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 import { Notification } from 'hds-react';
 import api, { Resource } from '../../common/utils/api/api';
-import { DatePeriod } from '../../common/lib/types';
 import Collapse from '../../components/collapse/Collapse';
 import { ExternalLink } from '../../components/link/Link';
 import ResourceOpeningHours from '../resource-opening-hours/ResourceOpeningHours';
@@ -87,7 +86,6 @@ const ResourceSourceLink = ({
 
 export default function ResourcePage({ id }: { id: string }): JSX.Element {
   const [resource, setResource] = useState<Resource | undefined>(undefined);
-  const [datePeriods, setDatePeriods] = useState<DatePeriod[]>([]);
   const [hasError, setError] = useState<Error | undefined>(undefined);
   const [isLoading, setLoading] = useState<boolean>(true);
 
@@ -105,21 +103,6 @@ export default function ResourcePage({ id }: { id: string }): JSX.Element {
         setLoading(false);
       });
   }, [id]);
-
-  useEffect((): void => {
-    // UseEffect's callbacks are synchronous to prevent a race condition.
-    // We can not use an async function as an useEffect's callback because it would return Promise<void>
-    if (resource) {
-      api
-        .getDatePeriod(resource.id)
-        .then((ds: DatePeriod[]) => {
-          setDatePeriods(ds);
-        })
-        .catch((e: Error) => {
-          setError(e);
-        });
-    }
-  }, [resource]);
 
   if (isLoading) {
     return (
@@ -152,9 +135,11 @@ export default function ResourcePage({ id }: { id: string }): JSX.Element {
         </p>
       </ResourceDetailsSection>
       <ResourceSourceLink id="resource-source-link" resource={resource} />
-      <ResourceSection id="resource-opening-hours">
-        <ResourceOpeningHours id={id} datePeriods={datePeriods} />
-      </ResourceSection>
+      {resource && (
+        <ResourceSection id="resource-opening-hours">
+          <ResourceOpeningHours id={id} resource={resource} />
+        </ResourceSection>
+      )}
     </>
   );
 }

--- a/src/resource/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/resource/resource-opening-hours/ResourceOpeningHours.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
-import { IconInfoCircle, Navigation, Button } from 'hds-react';
+import React, { useEffect, useState } from 'react';
+import { IconInfoCircle, Navigation, Button, Notification } from 'hds-react';
+import api, { Resource } from '../../common/utils/api/api';
+import { DatePeriod } from '../../common/lib/types';
 import OpeningPeriod from './opening-period/OpeningPeriod';
 import Collapse from '../../components/collapse/Collapse';
 import './ResourceOpeningHours.scss';
-import { DatePeriod } from '../../common/lib/types';
 
 enum PeriodsListTheme {
   DEFAULT = 'DEFAULT',
@@ -91,24 +92,77 @@ const OpeningPeriodsNotFound = ({ text }: { text: string }): JSX.Element => (
   <p className="opening-periods-not-found">{text}</p>
 );
 
-export default function ResourceOpeningHours({
+const ResourcePeriodsSection = ({
   id,
-  datePeriods,
+  children,
 }: {
   id: string;
-  datePeriods: DatePeriod[];
+  children: React.ReactNode;
+}): JSX.Element => (
+  <Collapse
+    isOpen
+    collapseContentId={`${id}-opening-hours-section`}
+    title="Toimipisteen aukiolotiedot">
+    <p>
+      Toimipisteen aukiolotietoja muokataan jaksokohtaisesti. Aukiolojaksot
+      voivat olla julkaistuja tai julkaisemattomia. Alla voit selata myös
+      tulevia ja menneitä aukiolojaksoja. Näet alla myös eri kieliversiot
+      valitsemalla kielen valikosta. Huomioithan, että palvelu voi itse valita
+      aukiolojaksojen esitystavan, se ei välttämättä ole alla näkyvän kaltainen.
+    </p>
+    {children}
+  </Collapse>
+);
+
+export default function ResourceOpeningHours({
+  id,
+  resource,
+}: {
+  id: string;
+  resource: Resource;
 }): JSX.Element {
-  const [
-    defaultPeriods = [],
-    exceptionPeriods = [],
-  ]: DatePeriod[][] = datePeriods.reduce(
-    ([defaults = [], exceptions = []]: DatePeriod[][], current: DatePeriod) => {
-      return current.override
-        ? [defaults, [...exceptions, current]]
-        : [[...defaults, current], exceptions];
-    },
-    []
-  );
+  const [defaultPeriods, setDefaultPeriods] = useState<DatePeriod[]>([]);
+  const [exceptionPeriods, setExeptionPeriods] = useState<DatePeriod[]>([]);
+  const [hasError, setError] = useState<Error | undefined>(undefined);
+  const [isLoading, setLoading] = useState<boolean>(true);
+
+  useEffect((): void => {
+    // UseEffect's callbacks are synchronous to prevent a race condition.
+    // We can not use an async function as an useEffect's callback because it would return Promise<void>
+    if (resource) {
+      api
+        .getDatePeriod(resource.id)
+        .then((datePeriods: DatePeriod[]) => {
+          setDefaultPeriods(
+            datePeriods.filter((period: DatePeriod) => !period.override)
+          );
+          setExeptionPeriods(
+            datePeriods.filter((period: DatePeriod) => period.override)
+          );
+          setLoading(false);
+        })
+        .catch((e: Error) => {
+          setError(e);
+          setLoading(false);
+        });
+    }
+  }, [resource]);
+
+  if (isLoading) {
+    return (
+      <ResourcePeriodsSection id={id}>
+        <p>Toimipisteen aukiolojaksoja ladataan...</p>
+      </ResourcePeriodsSection>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <ResourcePeriodsSection id={id}>
+        <Notification label="Aukiolojaksoja ei saatu ladattua." type="error" />
+      </ResourcePeriodsSection>
+    );
+  }
 
   return (
     <Collapse


### PR DESCRIPTION
- Move loading of date-periods inside opening-hour component and add loading and error state indicators/texts.

<img width="1404" alt="Näyttökuva 2020-11-13 kello 10 48 04" src="https://user-images.githubusercontent.com/1610860/99048299-0f7f6600-259e-11eb-98f0-adecf38e738f.png">

<img width="1367" alt="Näyttökuva 2020-11-13 kello 10 48 27" src="https://user-images.githubusercontent.com/1610860/99048284-0bebdf00-259e-11eb-9b14-bdf65ca9edc1.png">

