### PR TITLE
Fix some of the button colors for build version

### DIFF
--- a/src/opening-period/page/CreateNewOpeningPeriodPage.scss
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.scss
@@ -76,13 +76,13 @@
   margin-top: 116px;
 }
 
-.add-new-opening-period-final-action-button.add-new-opening-period-final-action-button {
+.add-new-opening-period-final-action-button.add-new-opening-period-final-action-button.add-new-opening-period-final-action-button {
   font-family: HelsinkiGrotesk-Medium, Arial, sans-serif;
   margin-right: $spacing-m;
   border-color: var(--color-coat-of-arms);
 }
 
-.publish-new-opening-period-button.publish-new-opening-period-button {
+.publish-new-opening-period-button.publish-new-opening-period-button.publish-new-opening-period-button {
   color: var(--add-new-opening-period-button-color);
   background-color: var(--color-coat-of-arms);
 
@@ -98,7 +98,7 @@
   }
 }
 
-.cancel-creation-of-new-opening-period-button.cancel-creation-of-new-opening-period-button {
+.cancel-creation-of-new-opening-period-button.cancel-creation-of-new-opening-period-button.cancel-creation-of-new-opening-period-button {
   color: var(--color-coat-of-arms);
 
   &:hover {


### PR DESCRIPTION
Fixes some of the button colors that were broken in build version:

![image](https://user-images.githubusercontent.com/2777633/99877223-4a6c4400-2c05-11eb-98db-92cb6be93738.png)


->

![image](https://user-images.githubusercontent.com/2777633/99877234-5952f680-2c05-11eb-9415-f7d236bc5e1f.png)


Hover state corrections:

![image](https://user-images.githubusercontent.com/2777633/99877272-7daed300-2c05-11eb-85f0-73b7dfae98dc.png)


-> 

![image](https://user-images.githubusercontent.com/2777633/99877285-8ef7df80-2c05-11eb-9193-b5c9a13d9082.png)

