### PR TITLE
Hauki 229 auth tokens in header

### DIFF
--- a/cypress/integration/User.spec.ts
+++ b/cypress/integration/User.spec.ts
@@ -25,7 +25,7 @@ describe('Authenticated user', () => {
           .click({ force: true });
         cy.get('header').first().find('a').contains('Kirjaudu ulos').click();
         cy.get('header').first().should('not.contain', 'Kirjaudu ulos');
-        cy.location('pathname').should('equal', '/unauthenticated');
+        cy.location('pathname').should('equal', '/');
 
         // Try to visit the resource page again
         cy.visit(resourcePageUrl);

--- a/cypress/integration/User.spec.ts
+++ b/cypress/integration/User.spec.ts
@@ -5,8 +5,8 @@ describe('Unauthenticated user', () => {
     cy.visitResourcePageAsUnauthenticatedUser(Cypress.env('resource-id'));
   });
 
-  it('Is redirected to front page', () => {
-    cy.location('pathname').should('equal', '/');
+  it('Is redirected to unauthenticated page', () => {
+    cy.location('pathname').should('equal', '/unauthenticated');
   });
 });
 
@@ -25,12 +25,12 @@ describe('Authenticated user', () => {
           .click({ force: true });
         cy.get('header').first().find('a').contains('Kirjaudu ulos').click();
         cy.get('header').first().should('not.contain', 'Kirjaudu ulos');
-        cy.location('pathname').should('equal', '/');
+        cy.location('pathname').should('equal', '/unauthenticated');
 
         // Try to visit the resource page again
         cy.visit(resourcePageUrl);
         cy.get('header').first().should('not.contain', 'Kirjaudu ulos');
-        cy.location('pathname').should('equal', '/');
+        cy.location('pathname').should('equal', '/unauthenticated');
       });
   });
 });

--- a/scripts/generate-auth-params.js
+++ b/scripts/generate-auth-params.js
@@ -22,13 +22,13 @@ const signature = crypto
   .digest('hex');
 
 const queryParameters = [
-  `source=${encodeURIComponent(source)}`,
-  `username=${encodeURIComponent(username)}`,
-  `created_at=${encodeURIComponent(createdAt)}`,
-  `valid_until=${encodeURIComponent(validUntil)}`,
-  `resource=${encodeURIComponent(resource)}`,
-  `organization=${encodeURIComponent(organization)}`,
-  `signature=${signature}`,
+  `hsa_source=${encodeURIComponent(source)}`,
+  `hsa_username=${encodeURIComponent(username)}`,
+  `hsa_created_at=${encodeURIComponent(createdAt)}`,
+  `hsa_valid_until=${encodeURIComponent(validUntil)}`,
+  `hsa_resource=${encodeURIComponent(resource)}`,
+  `hsa_organization=${encodeURIComponent(organization)}`,
+  `hsa_signature=${signature}`,
 ].join('&');
 
 process.stdout.write(queryParameters);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,9 @@ export default function App(): JSX.Element {
                 <Route exact path="/unauthorized">
                   <h1>Puutteelliset tunnukset</h1>
                 </Route>
+                <Route exact path="/unauthenticated">
+                  <h1>Puuttuvat tunnukset</h1>
+                </Route>
                 <PrivateResourceRoute
                   id="resource-route"
                   exact

--- a/src/auth/auth-context.test.ts
+++ b/src/auth/auth-context.test.ts
@@ -7,23 +7,23 @@ describe('Auth Context', () => {
     it('parses auth parameters from query string', () => {
       expect(
         parseAuthParams(
-          '?source=tprek&username=admin@hel.fi&signature=1234567&valid_until=2020-11-05T16%3A20%3A00&created_at=2020-11-05T16%3A10%3A00&organization=12345&resource=tprek%3A8215'
+          '?hsa_source=tprek&hsa_username=admin@hel.fi&hsa_signature=1234567&hsa_valid_until=2020-11-05T16%3A20%3A00&hsa_created_at=2020-11-05T16%3A10%3A00&hsa_organization=12345&hsa_resource=tprek%3A8215'
         )
       ).toEqual({
-        username: 'admin@hel.fi',
-        signature: '1234567',
-        valid_until: '2020-11-05T16:20:00',
-        created_at: '2020-11-05T16:10:00',
-        organization: '12345',
-        resource: 'tprek:8215',
-        source: 'tprek',
+        hsa_username: 'admin@hel.fi',
+        hsa_signature: '1234567',
+        hsa_valid_until: '2020-11-05T16:20:00',
+        hsa_created_at: '2020-11-05T16:10:00',
+        hsa_organization: '12345',
+        hsa_resource: 'tprek:8215',
+        hsa_source: 'tprek',
       });
     });
 
     it('returns undefined when a required parameter is missing', () => {
       expect(
         parseAuthParams(
-          '?username=admin@hel.fi&signature=1234567&valid_until=2020-11-05T16%3A20%3A00&created_at=2020-11-05T16%3A10%3A00'
+          '?hsa_username=admin@hel.fi&hsa_signature=1234567&hsa_valid_until=2020-11-05T16%3A20%3A00&hsa_created_at=2020-11-05T16%3A10%3A00'
         )
       ).toEqual(undefined);
     });

--- a/src/auth/auth-context.ts
+++ b/src/auth/auth-context.ts
@@ -2,32 +2,34 @@
 import querystring, { ParsedUrlQuery } from 'querystring';
 import { Context, createContext, useContext } from 'react';
 
-const usernameKey = 'username';
-const resourceKey = 'resource';
-const organizationKey = 'organization';
-const signatureKey = 'signature';
-const validUntilKey = 'valid_until';
-const createdAtKey = 'created_at';
-const sourceKey = 'source';
+export enum TokenKey {
+  usernameKey = 'username',
+  resourceKey = 'resource',
+  organizationKey = 'organization',
+  signatureKey = 'signature',
+  validUntilKey = 'valid_until',
+  createdAtKey = 'created_at',
+  sourceKey = 'source',
+}
 
 export interface AuthTokens {
-  [usernameKey]: string;
-  [resourceKey]: string;
-  [organizationKey]: string;
-  [signatureKey]: string;
-  [validUntilKey]: string;
-  [createdAtKey]: string;
-  [sourceKey]: string;
+  [TokenKey.usernameKey]: string;
+  [TokenKey.resourceKey]: string;
+  [TokenKey.organizationKey]: string;
+  [TokenKey.signatureKey]: string;
+  [TokenKey.validUntilKey]: string;
+  [TokenKey.createdAtKey]: string;
+  [TokenKey.sourceKey]: string;
 }
 
 const authKeys = [
-  usernameKey,
-  signatureKey,
-  validUntilKey,
-  createdAtKey,
-  resourceKey,
-  organizationKey,
-  sourceKey,
+  TokenKey.usernameKey,
+  TokenKey.signatureKey,
+  TokenKey.validUntilKey,
+  TokenKey.createdAtKey,
+  TokenKey.resourceKey,
+  TokenKey.organizationKey,
+  TokenKey.sourceKey,
 ];
 
 const tokenStorageKey: 'tokens' = 'tokens';

--- a/src/auth/auth-context.ts
+++ b/src/auth/auth-context.ts
@@ -6,7 +6,7 @@ export enum TokenKey {
   usernameKey = 'hsa_username',
   resourceKey = 'hsa_resource',
   organizationKey = 'hsa_organization',
-  signatureKey = 'signature',
+  signatureKey = 'hsa_signature',
   validUntilKey = 'hsa_valid_until',
   createdAtKey = 'hsa_created_at',
   sourceKey = 'hsa_source',

--- a/src/auth/auth-context.ts
+++ b/src/auth/auth-context.ts
@@ -3,13 +3,13 @@ import querystring, { ParsedUrlQuery } from 'querystring';
 import { Context, createContext, useContext } from 'react';
 
 export enum TokenKey {
-  usernameKey = 'username',
-  resourceKey = 'resource',
-  organizationKey = 'organization',
+  usernameKey = 'hsa_username',
+  resourceKey = 'hsa_resource',
+  organizationKey = 'hsa_organization',
   signatureKey = 'signature',
-  validUntilKey = 'valid_until',
-  createdAtKey = 'created_at',
-  sourceKey = 'source',
+  validUntilKey = 'hsa_valid_until',
+  createdAtKey = 'hsa_created_at',
+  sourceKey = 'hsa_source',
 }
 
 export interface AuthTokens {

--- a/src/auth/auth-context.ts
+++ b/src/auth/auth-context.ts
@@ -2,7 +2,7 @@
 import querystring, { ParsedUrlQuery } from 'querystring';
 import { Context, createContext, useContext } from 'react';
 
-export enum TokenKey {
+export enum TokenKeys {
   usernameKey = 'hsa_username',
   resourceKey = 'hsa_resource',
   organizationKey = 'hsa_organization',
@@ -13,23 +13,23 @@ export enum TokenKey {
 }
 
 export interface AuthTokens {
-  [TokenKey.usernameKey]: string;
-  [TokenKey.resourceKey]: string;
-  [TokenKey.organizationKey]: string;
-  [TokenKey.signatureKey]: string;
-  [TokenKey.validUntilKey]: string;
-  [TokenKey.createdAtKey]: string;
-  [TokenKey.sourceKey]: string;
+  [TokenKeys.usernameKey]: string;
+  [TokenKeys.resourceKey]: string;
+  [TokenKeys.organizationKey]: string;
+  [TokenKeys.signatureKey]: string;
+  [TokenKeys.validUntilKey]: string;
+  [TokenKeys.createdAtKey]: string;
+  [TokenKeys.sourceKey]: string;
 }
 
 const authKeys = [
-  TokenKey.usernameKey,
-  TokenKey.signatureKey,
-  TokenKey.validUntilKey,
-  TokenKey.createdAtKey,
-  TokenKey.resourceKey,
-  TokenKey.organizationKey,
-  TokenKey.sourceKey,
+  TokenKeys.usernameKey,
+  TokenKeys.signatureKey,
+  TokenKeys.validUntilKey,
+  TokenKeys.createdAtKey,
+  TokenKeys.resourceKey,
+  TokenKeys.organizationKey,
+  TokenKeys.sourceKey,
 ];
 
 const tokenStorageKey: 'tokens' = 'tokens';

--- a/src/common/utils/api/api.test.ts
+++ b/src/common/utils/api/api.test.ts
@@ -19,10 +19,10 @@ describe('apiRequest', () => {
       const resourceId = 'tprek:8100';
       const signature = '123456';
       const queryTokens = {
-        username: 'admin@hel.fi',
-        created_at: '2020-11-05T09%3A38%3A36.198Z',
-        valid_until: '2020-11-12T09%3A38%3A36.198Z',
-        source: 'tprek',
+        hsa_username: 'admin@hel.fi',
+        hsa_created_at: '2020-11-05T09%3A38%3A36.198Z',
+        hsa_valid_until: '2020-11-12T09%3A38%3A36.198Z',
+        hsa_source: 'tprek',
       };
       const mockTokens = { ...queryTokens, signature } as AuthTokens;
 
@@ -38,14 +38,14 @@ describe('apiRequest', () => {
         expect.objectContaining({
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `haukisigned username=${encodeURIComponent(
-              queryTokens.username
-            )}&created_at=${encodeURIComponent(
-              queryTokens.created_at
-            )}&valid_until=${encodeURIComponent(
-              queryTokens.valid_until
+            Authorization: `haukisigned hsa_username=${encodeURIComponent(
+              queryTokens.hsa_username
+            )}&hsa_created_at=${encodeURIComponent(
+              queryTokens.hsa_created_at
+            )}&hsa_valid_until=${encodeURIComponent(
+              queryTokens.hsa_valid_until
             )}&source=${encodeURIComponent(
-              queryTokens.source
+              queryTokens.hsa_source
             )}&signature=123456`,
           },
           method: 'post',

--- a/src/common/utils/api/api.test.ts
+++ b/src/common/utils/api/api.test.ts
@@ -17,14 +17,14 @@ describe('apiRequest', () => {
   describe('request', () => {
     it('adds auth-tokens into every request', async (done) => {
       const resourceId = 'tprek:8100';
-      const signature = '123456';
       const queryTokens = {
         hsa_username: 'admin@hel.fi',
         hsa_created_at: '2020-11-05T09%3A38%3A36.198Z',
         hsa_valid_until: '2020-11-12T09%3A38%3A36.198Z',
         hsa_source: 'tprek',
+        hsa_signature: '123456',
       };
-      const mockTokens = { ...queryTokens, signature } as AuthTokens;
+      const mockTokens = queryTokens as AuthTokens;
 
       jest.spyOn(auth, 'getTokens').mockImplementationOnce(() => mockTokens);
 
@@ -44,9 +44,9 @@ describe('apiRequest', () => {
               queryTokens.hsa_created_at
             )}&hsa_valid_until=${encodeURIComponent(
               queryTokens.hsa_valid_until
-            )}&source=${encodeURIComponent(
+            )}&hsa_source=${encodeURIComponent(
               queryTokens.hsa_source
-            )}&signature=123456`,
+            )}&hsa_signature=123456`,
           },
           method: 'post',
           url: 'http://localhost:8000/v1/resource/tprek:8100/permission_check/',

--- a/src/common/utils/api/api.test.ts
+++ b/src/common/utils/api/api.test.ts
@@ -22,6 +22,7 @@ describe('apiRequest', () => {
         username: 'admin@hel.fi',
         created_at: '2020-11-05T09%3A38%3A36.198Z',
         valid_until: '2020-11-12T09%3A38%3A36.198Z',
+        source: 'tprek',
       };
       const mockTokens = { ...queryTokens, signature } as AuthTokens;
 
@@ -37,10 +38,17 @@ describe('apiRequest', () => {
         expect.objectContaining({
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `haukisigned signature=${signature}`,
+            Authorization: `haukisigned username=${encodeURIComponent(
+              queryTokens.username
+            )}&created_at=${encodeURIComponent(
+              queryTokens.created_at
+            )}&valid_until=${encodeURIComponent(
+              queryTokens.valid_until
+            )}&source=${encodeURIComponent(
+              queryTokens.source
+            )}&signature=123456`,
           },
           method: 'post',
-          params: queryTokens,
           url: 'http://localhost:8000/v1/resource/tprek:8100/permission_check/',
           data: {},
         })

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -6,7 +6,7 @@ import {
   ResourceState,
   TimeSpanGroup,
 } from '../../lib/types';
-import { AuthTokens, getTokens } from '../../../auth/auth-context';
+import { AuthTokens, TokenKey, getTokens } from '../../../auth/auth-context';
 
 const apiBaseUrl: string = window.ENV?.API_URL || 'http://localhost:8000';
 
@@ -55,14 +55,18 @@ const addTokensToRequestConfig = (
   authTokens: AuthTokens,
   config: AxiosRequestConfig
 ): AxiosRequestConfig => {
-  const { signature, ...restOfTokens } = authTokens;
+  const tokensAsHeaderString: string = Object.keys(authTokens)
+    .map((key: string): string => {
+      return [key, encodeURIComponent(authTokens[key as TokenKey])].join('=');
+    })
+    .join('&');
+
   return {
     ...config,
     headers: {
       ...config.headers,
-      Authorization: `haukisigned signature=${signature}`,
+      Authorization: `haukisigned ${tokensAsHeaderString}`,
     },
-    params: { ...config.params, ...restOfTokens },
   };
 };
 

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -1,4 +1,6 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import * as querystring from 'querystring';
+import { ParsedUrlQueryInput } from 'querystring';
 import {
   DatePeriod,
   LanguageStrings,
@@ -6,7 +8,7 @@ import {
   ResourceState,
   TimeSpanGroup,
 } from '../../lib/types';
-import { AuthTokens, TokenKeys, getTokens } from '../../../auth/auth-context';
+import { AuthTokens, getTokens } from '../../../auth/auth-context';
 
 const apiBaseUrl: string = window.ENV?.API_URL || 'http://localhost:8000';
 
@@ -55,17 +57,13 @@ const addTokensToRequestConfig = (
   authTokens: AuthTokens,
   config: AxiosRequestConfig
 ): AxiosRequestConfig => {
-  const tokensAsHeaderString: string = Object.keys(authTokens)
-    .map((key: string): string => {
-      return [key, encodeURIComponent(authTokens[key as TokenKeys])].join('=');
-    })
-    .join('&');
-
   return {
     ...config,
     headers: {
       ...config.headers,
-      Authorization: `haukisigned ${tokensAsHeaderString}`,
+      Authorization: `haukisigned ${querystring.stringify(
+        (authTokens as unknown) as ParsedUrlQueryInput
+      )}`,
     },
   };
 };

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -6,7 +6,7 @@ import {
   ResourceState,
   TimeSpanGroup,
 } from '../../lib/types';
-import { AuthTokens, TokenKey, getTokens } from '../../../auth/auth-context';
+import { AuthTokens, TokenKeys, getTokens } from '../../../auth/auth-context';
 
 const apiBaseUrl: string = window.ENV?.API_URL || 'http://localhost:8000';
 
@@ -57,7 +57,7 @@ const addTokensToRequestConfig = (
 ): AxiosRequestConfig => {
   const tokensAsHeaderString: string = Object.keys(authTokens)
     .map((key: string): string => {
-      return [key, encodeURIComponent(authTokens[key as TokenKey])].join('=');
+      return [key, encodeURIComponent(authTokens[key as TokenKeys])].join('=');
     })
     .join('&');
 

--- a/src/components/navigation/HaukiNavigation.tsx
+++ b/src/components/navigation/HaukiNavigation.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Navigation } from 'hds-react';
 import api from '../../common/utils/api/api';
-import { AuthContextProps, useAuth } from '../../auth/auth-context';
+import { AuthContextProps, TokenKey, useAuth } from '../../auth/auth-context';
 import './HaukiNavigation.scss';
 import { ErrorToast } from '../notification/Toast';
 
@@ -73,7 +73,7 @@ export default function HaukiNavigation(): JSX.Element {
         <Navigation.User
           authenticated={isAuthenticated}
           label="Kirjaudu"
-          userName={authTokens?.username}>
+          userName={authTokens && authTokens[TokenKey.usernameKey]}>
           <Navigation.Item
             label="Kirjaudu ulos"
             target="_blank"

--- a/src/components/navigation/HaukiNavigation.tsx
+++ b/src/components/navigation/HaukiNavigation.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Navigation } from 'hds-react';
 import api from '../../common/utils/api/api';
-import { AuthContextProps, TokenKey, useAuth } from '../../auth/auth-context';
+import { AuthContextProps, TokenKeys, useAuth } from '../../auth/auth-context';
 import './HaukiNavigation.scss';
 import { ErrorToast } from '../notification/Toast';
 
@@ -73,7 +73,7 @@ export default function HaukiNavigation(): JSX.Element {
         <Navigation.User
           authenticated={isAuthenticated}
           label="Kirjaudu"
-          userName={authTokens && authTokens[TokenKey.usernameKey]}>
+          userName={authTokens && authTokens[TokenKeys.usernameKey]}>
           <Navigation.Item
             label="Kirjaudu ulos"
             target="_blank"

--- a/src/resource/PrivateResourceRoute.test.tsx
+++ b/src/resource/PrivateResourceRoute.test.tsx
@@ -9,21 +9,28 @@ import {
 import api from '../common/utils/api/api';
 import * as AuthContext from '../auth/auth-context';
 import PrivateResourceRoute from './PrivateResourceRoute';
+import { AuthTokens } from '../auth/auth-context';
 
-const testTokens = {
-  username: 'admin@hel.fi',
-  created_at: '2020-11-05',
-  valid_until: '2020-11-12',
-  resource: 'tprek:8100',
-  organization: 'abcdefg',
+const testTokens: AuthTokens = {
+  hsa_username: 'admin@hel.fi',
+  hsa_created_at: '2020-11-05',
+  hsa_valid_until: '2020-11-12',
+  hsa_resource: 'tprek:8100',
+  hsa_organization: 'abcdefg',
+  hsa_signature: '1234567',
+  hsa_source: 'tprek',
 };
 
 const renderRoutesWithPrivateRoute = (): ReactWrapper => {
-  window.history.pushState({}, 'Test page', `/resource/${testTokens.resource}`);
+  window.history.pushState(
+    {},
+    'Test page',
+    `/resource/${testTokens.hsa_resource}`
+  );
   return mount(
     <Router>
-      <Route exact path="/">
-        <h1>Test home</h1>
+      <Route exact path="/unauthenticated">
+        <h1>Test unauthenticated</h1>
       </Route>
       <Route exact path="/unauthorized">
         <h1>Test unauthorized</h1>
@@ -94,7 +101,9 @@ describe(`<PrivateResourceRoute />`, () => {
       renderedComponent.update();
     });
 
-    expect(renderedComponent.find('h1').text()).toEqual(testTokens.resource);
+    expect(renderedComponent.find('h1').text()).toEqual(
+      testTokens.hsa_resource
+    );
   });
 
   it('should redirect to /unauthorized', async () => {
@@ -114,7 +123,7 @@ describe(`<PrivateResourceRoute />`, () => {
     expect(renderedComponent.find('h1').text()).toEqual('Test unauthorized');
   });
 
-  it('should redirect to /', async () => {
+  it('should redirect to /unauthenticated', async () => {
     mockContext({ tokens: undefined });
     mockPermissionsApi(false);
 
@@ -128,6 +137,6 @@ describe(`<PrivateResourceRoute />`, () => {
       renderedComponent.update();
     });
 
-    expect(renderedComponent.find('h1').text()).toEqual('Test home');
+    expect(renderedComponent.find('h1').text()).toEqual('Test unauthenticated');
   });
 });

--- a/src/resource/PrivateResourceRoute.tsx
+++ b/src/resource/PrivateResourceRoute.tsx
@@ -4,6 +4,7 @@ import {
   Redirect,
   RouteProps,
   RouteComponentProps,
+  useLocation,
 } from 'react-router-dom';
 import { AuthContextProps, useAuth } from '../auth/auth-context';
 import api from '../common/utils/api/api';
@@ -16,6 +17,7 @@ const PermissionResolver = ({
   children?: ReactNode;
 }): JSX.Element => {
   const { authTokens, clearAuth }: Partial<AuthContextProps> = useAuth();
+  const { search } = useLocation();
   const isAuthenticated = !!authTokens;
   const [isLoading, setLoading] = useState<boolean>(true);
   const [isAuthorized, setIsAuthorized] = useState<boolean>(false);
@@ -48,11 +50,11 @@ const PermissionResolver = ({
   }
 
   if (!isAuthenticated) {
-    return <Redirect to="/" />;
+    return <Redirect to={{ pathname: '/unauthenticated', search }} />;
   }
 
   if (!isAuthorized) {
-    return <Redirect to="/unauthorized" />;
+    return <Redirect to={{ pathname: '/unauthorized', search }} />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
- Send auth-tokens in request-header
- Add hsa-prefix into auth-tokens
- Pass query-params in redirects for debugging

Depends on: https://github.com/City-of-Helsinki/hauki/pull/39