### PR TITLE
Add trailing slash into GET-requests

### DIFF
--- a/src/common/utils/api/api.test.ts
+++ b/src/common/utils/api/api.test.ts
@@ -93,7 +93,7 @@ describe('apiRequest', () => {
         headers: { 'Content-Type': 'application/json' },
         method: 'get',
         params: { format: 'json' },
-        url: 'http://localhost:8000/v1/resource/tprek:8100',
+        url: 'http://localhost:8000/v1/resource/tprek:8100/',
       });
 
       expect(response).toBe(mockResource);

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -96,7 +96,7 @@ async function apiGet<T>({ path, parameters = {} }: GetParameters): Promise<T> {
   };
 
   return request<T>({
-    url: `${apiBaseUrl}/v1${path}`,
+    url: `${apiBaseUrl}/v1${path}/`,
     headers: {
       'Content-Type': 'application/json',
     },


### PR DESCRIPTION
- Add missing trailing slash into API GET-requests. Prevents unnecessary 302 API redirects