### PR TITLE
Hauki 224 language select

### DIFF
--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -1,4 +1,13 @@
-export type Language = 'fi' | 'sv' | 'en';
+export enum Language {
+  FI = 'fi',
+  SV = 'sv',
+  EN = 'en',
+}
+
+export type LanguageOption = {
+  label: string;
+  value: Language;
+};
 
 export type LanguageStrings = {
   [x in Language]: string | null;

--- a/src/components/language-select/LanguageSelect.scss
+++ b/src/components/language-select/LanguageSelect.scss
@@ -1,0 +1,7 @@
+.custom-language-select {
+  font-weight: bold !important;
+}
+
+.custom-language-select--dark {
+  color: var(--color-coat-of-arms) !important;
+}

--- a/src/components/language-select/LanguageSelect.test.tsx
+++ b/src/components/language-select/LanguageSelect.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Language } from '../../common/lib/types';
+import LanguageSelect from './LanguageSelect';
+
+describe(`<LanguageSelect />`, () => {
+  it('should show selected language', () => {
+    let selectedLanguage = Language.FI;
+
+    // eslint-disable-next-line no-return-assign
+    const onSelect = (language: Language): Language =>
+      (selectedLanguage = language);
+
+    render(
+      <LanguageSelect
+        id="test-select"
+        label="test-select"
+        selectedLanguage={selectedLanguage}
+        onSelect={onSelect}
+      />
+    );
+
+    expect(screen.getAllByText('FI').length).toEqual(1);
+  });
+});

--- a/src/components/language-select/LanguageSelect.test.tsx
+++ b/src/components/language-select/LanguageSelect.test.tsx
@@ -4,12 +4,15 @@ import { Language } from '../../common/lib/types';
 import LanguageSelect from './LanguageSelect';
 
 describe(`<LanguageSelect />`, () => {
-  it('should show selected language', () => {
+  it('should show formatted selected language', () => {
     let selectedLanguage = Language.FI;
 
     // eslint-disable-next-line no-return-assign
     const onSelect = (language: Language): Language =>
       (selectedLanguage = language);
+
+    const formatter = (language: Language): string =>
+      `Esityskieli: ${language}`;
 
     render(
       <LanguageSelect
@@ -17,9 +20,10 @@ describe(`<LanguageSelect />`, () => {
         label="test-select"
         selectedLanguage={selectedLanguage}
         onSelect={onSelect}
+        formatter={formatter}
       />
     );
 
-    expect(screen.getAllByText('FI').length).toEqual(1);
+    expect(screen.getAllByText('Esityskieli: fi').length).toEqual(1);
   });
 });

--- a/src/components/language-select/LanguageSelect.tsx
+++ b/src/components/language-select/LanguageSelect.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Navigation } from 'hds-react';
+import { Language, LanguageOption } from '../../common/lib/types';
+import './LanguageSelect.scss';
+
+export const languageOptions: LanguageOption[] = [
+  { label: 'Suomeksi', value: Language.FI },
+  { label: 'Svenska', value: Language.SV },
+  { label: 'English', value: Language.EN },
+];
+
+export const getMissingText = ({
+  language,
+  label,
+}: {
+  language: Language;
+  label: string;
+}): string => {
+  const texts = {
+    [Language.FI]: `Suomenkielinen ${label} puuttuu.`,
+    [Language.SV]: `Ruotsinkielinen ${label} puuttuu.`,
+    [Language.EN]: `Englanninkielinen ${label} puuttuu.`,
+  };
+  return texts[language];
+};
+
+const formatSelectedLanguage = (selectedLanguage: Language): string =>
+  selectedLanguage.toUpperCase();
+
+export default function LanguageSelect({
+  id,
+  label,
+  className,
+  selectedLanguage,
+  onSelect,
+  formatter = formatSelectedLanguage,
+  theme,
+}: {
+  id: string;
+  label: string;
+  className?: string;
+  selectedLanguage: Language;
+  onSelect: (language: Language) => void;
+  formatter?: (selectedLanguage: Language) => string;
+  theme?: 'dark';
+}): JSX.Element {
+  const componentClassName = `custom-language-select${
+    theme ? ` custom-language-select--${theme}` : ''
+  }${className ? ` ${className}` : ''}`;
+
+  return (
+    <Navigation.LanguageSelector
+      id={id}
+      buttonAriaLabel={label}
+      className={componentClassName}
+      label={formatter(selectedLanguage)}>
+      {languageOptions.map((languageOption) => (
+        <Navigation.Item
+          key={languageOption.value}
+          label={languageOption.label}
+          onClick={(
+            e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
+          ): void => {
+            e.preventDefault();
+            onSelect(languageOption.value);
+          }}
+        />
+      ))}
+    </Navigation.LanguageSelector>
+  );
+}

--- a/src/components/language-select/LanguageSelect.tsx
+++ b/src/components/language-select/LanguageSelect.tsx
@@ -9,7 +9,7 @@ export const languageOptions: LanguageOption[] = [
   { label: 'English', value: Language.EN },
 ];
 
-export const getMissingText = ({
+export const displayLangVersionNotFound = ({
   language,
   label,
 }: {

--- a/src/components/navigation/HaukiNavigation.tsx
+++ b/src/components/navigation/HaukiNavigation.tsx
@@ -13,21 +13,6 @@ export default function HaukiNavigation(): JSX.Element {
   const history = useHistory();
   const isAuthenticated = !!authTokens;
 
-  interface LanguageOption {
-    label: string;
-    value: string;
-  }
-
-  const languageOptions: LanguageOption[] = [
-    { label: 'Suomeksi', value: 'fi' },
-    { label: 'Svenska', value: 'sv' },
-    { label: 'English', value: 'en' },
-  ];
-
-  const [language, setLanguage] = useState(languageOptions[0]);
-  const formatSelectedValue = ({ value }: LanguageOption): string =>
-    value.toUpperCase();
-
   const signOut = async (): Promise<void> => {
     try {
       const isAuthInvalidated = await api.invalidateAuth();
@@ -81,20 +66,6 @@ export default function HaukiNavigation(): JSX.Element {
             onClick={(): Promise<void> => signOut()}
           />
         </Navigation.User>
-        <Navigation.LanguageSelector label={formatSelectedValue(language)}>
-          {languageOptions.map((languageOption) => (
-            <Navigation.Item
-              key={languageOption.value}
-              label={languageOption.label}
-              onClick={(
-                e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
-              ): void => {
-                e.preventDefault();
-                setLanguage(languageOption);
-              }}
-            />
-          ))}
-        </Navigation.LanguageSelector>
       </Navigation.Actions>
       {signOutError && (
         <ErrorToast label="Uloskirjautuminen epäonnistui" text={signOutError} />

--- a/src/index.scss
+++ b/src/index.scss
@@ -50,3 +50,7 @@ label {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+.text-danger {
+  color: var(--color-brick-dark);
+}

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.scss
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.scss
@@ -1,11 +1,5 @@
 @import 'node_modules/hds-design-tokens/lib/all.scss';
 
-.opening-period-page-header-row {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-}
-
 .add-new-opening-period-page-title {
   margin-top: $spacing-2-xs;
   font-size: $fontsize-heading-m;

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.tsx
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.tsx
@@ -5,7 +5,11 @@ import { useHistory } from 'react-router-dom';
 import formatDate from 'date-fns/format';
 import parse from 'date-fns/parse';
 import api from '../../common/utils/api/api';
-import { ResourceInfo } from '../../resource/page/ResourcePage';
+import {
+  ResourceAddress,
+  ResourceInfo,
+  ResourceTitle,
+} from '../../resource/page/ResourcePage';
 import Datepicker from '../../components/datepicker/Datepicker';
 import { ErrorToast, SuccessToast } from '../../components/notification/Toast';
 import './CreateNewOpeningPeriodPage.scss';
@@ -209,10 +213,14 @@ export default function CreateNewOpeningPeriodPage({
         />
       )}
       <div className="opening-period-page-header-row">
-        <ResourceInfo resource={resource} />
-        <h2 className="add-new-opening-period-page-title">
-          Toimipisteen aukiolojakson lisäys
-        </h2>
+        <ResourceInfo>
+          <ResourceTitle resource={resource}>
+            <h2 className="add-new-opening-period-page-title">
+              Toimipisteen aukiolojakson lisäys
+            </h2>
+          </ResourceTitle>
+          <ResourceAddress resource={resource} />
+        </ResourceInfo>
       </div>
       <form
         id="add-new-opening-period-form"

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.tsx
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.tsx
@@ -212,16 +212,14 @@ export default function CreateNewOpeningPeriodPage({
           onClose={(): void => setSubmitStatus('init')}
         />
       )}
-      <div className="opening-period-page-header-row">
-        <ResourceInfo>
-          <ResourceTitle resource={resource}>
-            <h2 className="add-new-opening-period-page-title">
-              Toimipisteen aukiolojakson lisäys
-            </h2>
-          </ResourceTitle>
-          <ResourceAddress resource={resource} />
-        </ResourceInfo>
-      </div>
+      <ResourceInfo>
+        <ResourceTitle resource={resource}>
+          <h2 className="add-new-opening-period-page-title">
+            Toimipisteen aukiolojakson lisäys
+          </h2>
+        </ResourceTitle>
+        <ResourceAddress resource={resource} />
+      </ResourceInfo>
       <form
         id="add-new-opening-period-form"
         data-test="add-new-opening-period-form"

--- a/src/opening-period/page/EditOpeningPeriodPage.scss
+++ b/src/opening-period/page/EditOpeningPeriodPage.scss
@@ -1,11 +1,5 @@
 @import 'node_modules/hds-design-tokens/lib/all.scss';
 
-.opening-period-page-header-row {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-}
-
 .opening-period-page-title {
   margin-top: $spacing-2-xs;
   font-size: $fontsize-heading-m;

--- a/src/opening-period/page/EditOpeningPeriodPage.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Control, Controller, FieldValues, useForm } from 'react-hook-form';
-import { Button, Notification, LoadingSpinner } from 'hds-react';
+import { Button, LoadingSpinner, Notification } from 'hds-react';
 import { useHistory } from 'react-router-dom';
 import api from '../../common/utils/api/api';
 import {
@@ -12,7 +12,11 @@ import {
 import { transformToApiFormat } from '../../common/utils/date-time/format';
 import Datepicker from '../../components/datepicker/Datepicker';
 import { ErrorToast, SuccessToast } from '../../components/notification/Toast';
-import { ResourceInfo } from '../../resource/page/ResourcePage';
+import {
+  ResourceInfo,
+  ResourceTitle,
+  ResourceAddress,
+} from '../../resource/page/ResourcePage';
 import './EditOpeningPeriodPage.scss';
 
 type FormData = {
@@ -60,7 +64,7 @@ export default function EditOpeningPeriodPage({
   datePeriodId: string;
 }): JSX.Element {
   const id = parseInt(datePeriodId, 10);
-  const selectedLanguage: Language = 'fi';
+  const selectedLanguage: Language = Language.FI;
   const [resource, setResource] = useState<Resource>();
   const [hasDataLoadingError, setHasDataLoadingError] = useState<
     Error | undefined
@@ -81,7 +85,7 @@ export default function EditOpeningPeriodPage({
         openingPeriodBeginDate: datePeriod.start_date || undefined,
         openingPeriodEndDate: datePeriod.end_date || undefined,
       }),
-    [reset]
+    [reset, selectedLanguage]
   );
 
   const onSubmit = async (data: FormData): Promise<void> => {
@@ -178,10 +182,14 @@ export default function EditOpeningPeriodPage({
         />
       )}
       <div className="opening-period-page-header-row">
-        <ResourceInfo resource={resource} />
-        <h2 className="opening-period-page-title">
-          Toimipisteen aukiolojakson muokkaus
-        </h2>
+        <ResourceInfo>
+          <ResourceTitle resource={resource}>
+            <h2 className="opening-period-page-title">
+              Toimipisteen aukiolojakson muokkaus
+            </h2>
+          </ResourceTitle>
+          <ResourceAddress resource={resource} />
+        </ResourceInfo>
       </div>
       <form
         id="opening-period-form"

--- a/src/opening-period/page/EditOpeningPeriodPage.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.tsx
@@ -181,16 +181,14 @@ export default function EditOpeningPeriodPage({
           onClose={(): void => setSubmitStatus('init')}
         />
       )}
-      <div className="opening-period-page-header-row">
-        <ResourceInfo>
-          <ResourceTitle resource={resource}>
-            <h2 className="opening-period-page-title">
-              Toimipisteen aukiolojakson muokkaus
-            </h2>
-          </ResourceTitle>
-          <ResourceAddress resource={resource} />
-        </ResourceInfo>
-      </div>
+      <ResourceInfo>
+        <ResourceTitle resource={resource}>
+          <h2 className="opening-period-page-title">
+            Toimipisteen aukiolojakson muokkaus
+          </h2>
+        </ResourceTitle>
+        <ResourceAddress resource={resource} />
+      </ResourceInfo>
       <form
         id="opening-period-form"
         data-test="opening-period-form"

--- a/src/resource/page/ResourcePage.scss
+++ b/src/resource/page/ResourcePage.scss
@@ -3,6 +3,11 @@
   padding: var(--spacing-layout-2-xs) 0;
 }
 
+.resource-info-title-wrapper {
+  align-items: center;
+  display: flex;
+}
+
 .resource-info-title {
   font-size: var(--fontsize-heading-l);
   margin-top: 0;

--- a/src/resource/page/ResourcePage.scss
+++ b/src/resource/page/ResourcePage.scss
@@ -8,6 +8,10 @@
   display: flex;
 }
 
+.resource-info-title-add-on {
+  margin-left: auto;
+}
+
 .resource-info-title {
   font-size: var(--fontsize-heading-l);
   margin-top: 0;

--- a/src/resource/page/ResourcePage.scss
+++ b/src/resource/page/ResourcePage.scss
@@ -26,7 +26,3 @@
 .resource-description-text {
   white-space: pre-wrap;
 }
-
-.resource-info-container {
-  flex-direction: column;
-}

--- a/src/resource/page/ResourcePage.tsx
+++ b/src/resource/page/ResourcePage.tsx
@@ -57,7 +57,9 @@ export const ResourceInfo = ({
   children,
 }: {
   children: ReactNode;
-}): JSX.Element => <div className="resource-info-container">{children}</div>;
+}): JSX.Element => (
+  <section aria-label="Toimipisteen tiedot">{children}</section>
+);
 
 const ResourceSection = ({
   id,

--- a/src/resource/page/ResourcePage.tsx
+++ b/src/resource/page/ResourcePage.tsx
@@ -207,7 +207,11 @@ export default function ResourcePage({ id }: { id: string }): JSX.Element {
       </ResourceInfo>
       <ResourceDetailsSection id="resource-description" title="Perustiedot">
         <p className="resource-description-text">
-          {resource?.description[language] || 'Toimipisteellä ei ole kuvausta.'}
+          {resource?.description[language] ||
+            displayLangVersionNotFound({
+              language,
+              label: 'toimipisteen kuvaus',
+            })}
         </p>
       </ResourceDetailsSection>
       <ResourceSourceLink id="resource-source-link" resource={resource} />

--- a/src/resource/page/ResourcePage.tsx
+++ b/src/resource/page/ResourcePage.tsx
@@ -4,7 +4,7 @@ import api from '../../common/utils/api/api';
 import { DatePeriod, Language, Resource } from '../../common/lib/types';
 import Collapse from '../../components/collapse/Collapse';
 import LanguageSelect, {
-  getMissingText,
+  displayLangVersionNotFound,
 } from '../../components/language-select/LanguageSelect';
 import { ExternalLink } from '../../components/link/Link';
 import LoadingIndicator from '../../components/loadingIndicator/LoadingIndicator';
@@ -21,7 +21,8 @@ export const ResourceTitle = ({
   children: ReactNode;
 }): JSX.Element => {
   const name =
-    resource?.name[language] || getMissingText({ language, label: 'nimi' });
+    resource?.name[language] ||
+    displayLangVersionNotFound({ language, label: 'toimipisteen nimi' });
 
   return (
     <div className="resource-info-title-wrapper">
@@ -42,7 +43,7 @@ export const ResourceAddress = ({
 }): JSX.Element => {
   const address =
     resource?.address[language] ||
-    getMissingText({ language, label: 'address' });
+    displayLangVersionNotFound({ language, label: 'toimipisteen osoite' });
 
   return (
     <>

--- a/src/resource/page/ResourcePage.tsx
+++ b/src/resource/page/ResourcePage.tsx
@@ -11,6 +11,8 @@ import LoadingIndicator from '../../components/loadingIndicator/LoadingIndicator
 import ResourceOpeningHours from '../resource-opening-hours/ResourceOpeningHours';
 import './ResourcePage.scss';
 
+const resourceTitleId = 'resource-title';
+
 export const ResourceTitle = ({
   resource,
   language = Language.FI,
@@ -26,7 +28,10 @@ export const ResourceTitle = ({
 
   return (
     <div className="resource-info-title-wrapper">
-      <h1 data-test="resource-info" className="resource-info-title">
+      <h1
+        id={resourceTitleId}
+        data-test="resource-info"
+        className="resource-info-title">
         {name}
       </h1>
       <div className="resource-info-title-add-on">{children}</div>
@@ -58,7 +63,7 @@ export const ResourceInfo = ({
 }: {
   children: ReactNode;
 }): JSX.Element => (
-  <section aria-label="Toimipisteen tiedot">{children}</section>
+  <section aria-labelledby={resourceTitleId}>{children}</section>
 );
 
 const ResourceSection = ({

--- a/src/resource/resource-opening-hours/ResourceOpeningHours.scss
+++ b/src/resource/resource-opening-hours/ResourceOpeningHours.scss
@@ -56,10 +56,6 @@
   align-items: center;
   display: flex;
   flex-direction: row;
-
-  > * + * {
-    margin-left: $spacing-xl;
-  }
 }
 
 .opening-periods-header-title {
@@ -72,6 +68,12 @@
 
 .opening-periods-header-info {
   color: inherit;
+}
+
+.opening-periods-header-actions {
+  > * + * {
+    margin-left: $spacing-xl;
+  }
 }
 
 .period-count {

--- a/src/resource/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/resource/resource-opening-hours/ResourceOpeningHours.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { IconInfoCircle, Navigation, Button } from 'hds-react';
+import { IconInfoCircle, Button } from 'hds-react';
 import { useHistory } from 'react-router-dom';
-import OpeningPeriod from './opening-period/OpeningPeriod';
 import Collapse from '../../components/collapse/Collapse';
+import LanguageSelect from '../../components/language-select/LanguageSelect';
+import OpeningPeriod from './opening-period/OpeningPeriod';
 import './ResourceOpeningHours.scss';
-import { DatePeriod } from '../../common/lib/types';
+import { DatePeriod, Language } from '../../common/lib/types';
 
 enum PeriodsListTheme {
   DEFAULT = 'DEFAULT',
@@ -33,20 +34,8 @@ const OpeningPeriodsList = ({
       ? 'opening-periods-header-light'
       : 'opening-periods-header';
 
-  interface LanguageOption {
-    label: string;
-    value: string;
-  }
-
-  const languageOptions: LanguageOption[] = [
-    { label: 'Suomeksi', value: 'fi' },
-    { label: 'Svenska', value: 'sv' },
-    { label: 'English', value: 'en' },
-  ];
   const history = useHistory();
-  const [language, setLanguage] = useState(languageOptions[0]);
-  const formatSelectedValue = ({ value }: LanguageOption): string =>
-    value.toUpperCase();
+  const [language, setLanguage] = useState(Language.FI);
 
   return (
     <section className="opening-periods-section">
@@ -61,20 +50,12 @@ const OpeningPeriodsList = ({
         </div>
         <div className="opening-periods-header-container">
           <p className="period-count">{datePeriods.length} jaksoa</p>
-          <Navigation.LanguageSelector label={formatSelectedValue(language)}>
-            {languageOptions.map((languageOption) => (
-              <Navigation.Item
-                key={languageOption.value}
-                label={languageOption.label}
-                onClick={(
-                  e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
-                ): void => {
-                  e.preventDefault();
-                  setLanguage(languageOption);
-                }}
-              />
-            ))}
-          </Navigation.LanguageSelector>
+          <LanguageSelect
+            id={`${id}-language-select`}
+            label={`${title}-listan kielivalinta`}
+            selectedLanguage={language}
+            onSelect={setLanguage}
+          />
           <Button
             data-test={addNewOpeningPeriodButtonDataTest}
             size="small"
@@ -91,7 +72,11 @@ const OpeningPeriodsList = ({
         {datePeriods.length > 0 ? (
           datePeriods.map((datePeriod: DatePeriod) => (
             <li key={datePeriod.id}>
-              <OpeningPeriod datePeriod={datePeriod} resourceId={resourceId} />
+              <OpeningPeriod
+                datePeriod={datePeriod}
+                resourceId={resourceId}
+                language={language}
+              />
             </li>
           ))
         ) : (

--- a/src/resource/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/resource/resource-opening-hours/ResourceOpeningHours.tsx
@@ -48,7 +48,7 @@ const OpeningPeriodsList = ({
             className="opening-periods-header-info"
           />
         </div>
-        <div className="opening-periods-header-container">
+        <div className="opening-periods-header-container opening-periods-header-actions">
           <p className="period-count">{datePeriods.length} jaksoa</p>
           <LanguageSelect
             id={`${id}-language-select`}

--- a/src/resource/resource-opening-hours/opening-period/OpeningPeriod.tsx
+++ b/src/resource/resource-opening-hours/opening-period/OpeningPeriod.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { IconPenLine } from 'hds-react';
 import { DatePeriod, Language } from '../../../common/lib/types';
 import { formatDateRange } from '../../../common/utils/date-time/format';
-import { getMissingText } from '../../../components/language-select/LanguageSelect';
+import { displayLangVersionNotFound } from '../../../components/language-select/LanguageSelect';
 import './OpeningPeriod.scss';
 
 export default function OpeningPeriod({
@@ -33,7 +33,10 @@ export default function OpeningPeriod({
             <h4>{name}</h4>
           ) : (
             <h4 className="text-danger">
-              {getMissingText({ language, label: 'nimi' })}
+              {displayLangVersionNotFound({
+                language,
+                label: 'aukiolojakson nimi',
+              })}
             </h4>
           )}
         </div>

--- a/src/resource/resource-opening-hours/opening-period/OpeningPeriod.tsx
+++ b/src/resource/resource-opening-hours/opening-period/OpeningPeriod.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { IconPenLine } from 'hds-react';
-import { DatePeriod } from '../../../common/lib/types';
+import { DatePeriod, Language } from '../../../common/lib/types';
 import { formatDateRange } from '../../../common/utils/date-time/format';
+import { getMissingText } from '../../../components/language-select/LanguageSelect';
 import './OpeningPeriod.scss';
 
 export default function OpeningPeriod({
   resourceId,
   datePeriod,
+  language,
 }: {
   resourceId: string;
   datePeriod: DatePeriod;
+  language: Language;
 }): JSX.Element {
-  const name = datePeriod.name?.fi;
+  const name = datePeriod.name[language];
 
   return (
     <div className="opening-period">
@@ -26,7 +29,13 @@ export default function OpeningPeriod({
           </div>
         </div>
         <div className="opening-period-title opening-period-row-column">
-          <h4>{datePeriod.name?.fi}</h4>
+          {name ? (
+            <h4>{name}</h4>
+          ) : (
+            <h4 className="text-danger">
+              {getMissingText({ language, label: 'nimi' })}
+            </h4>
+          )}
         </div>
         <div className="opening-period-actions opening-period-row-column">
           <Link


### PR DESCRIPTION
- Add Language-select component
- Refactor resource-info-title in a way that it can have either subtitle or language-select as a child component
- Use Language-select in resource details
- Use Language-select in date-period lists
- Remove application Language-Selector as unnecessary for now

Resource details:
<img width="1373" alt="Näyttökuva 2020-12-8 kello 10 10 19" src="https://user-images.githubusercontent.com/1610860/101457206-e0aaa480-393d-11eb-894d-144804624b4c.png">


Date-period list:
<img width="1547" alt="Näyttökuva 2020-12-8 kello 10 11 57" src="https://user-images.githubusercontent.com/1610860/101457215-e43e2b80-393d-11eb-80ba-9a2422d91117.png">
