### PR TITLE
HAUKI-118 Increase css specificity to fix app in test environment

### DIFF
--- a/src/opening-period/time-span/TimeSpan.scss
+++ b/src/opening-period/time-span/TimeSpan.scss
@@ -1,6 +1,6 @@
 @import 'node_modules/hds-design-tokens/lib/all.scss';
 
-.remove-time-span-button {
+.remove-time-span-button.remove-time-span-button {
   color: var(--color-coat-of-arms);
 }
 


### PR DESCRIPTION
HDS styles override our styles in build-mode of the application, so we need to add specificity of the css selector