### PR TITLE
Hauki-271 Add tests for EditOpeningPeriodPage

### DIFF
--- a/src/opening-period/form/OpeningPeriodForm.scss
+++ b/src/opening-period/form/OpeningPeriodForm.scss
@@ -43,13 +43,20 @@
   margin-bottom: $spacing-layout-xs;
 }
 
-.time-span-list-container {
-  position: relative;
+.opening-period-time-span-list {
   border-bottom: 1px solid var(--hauki-content-border-color);
-  padding-top: 0;
-  padding-bottom: var(--spacing-layout-xs);
+  margin: 0;
+  padding: 0 0 var(--spacing-layout-xs);
+  position: relative;
 
-  & > div:first-of-type {
+  li {
+    list-style: none;
+    border-top: var(--spacing-4-xs) solid var(--primary-color);
+    margin: $spacing-2-xl 0 0;
+    padding: 0;
+  }
+
+  > li:first-child {
     border-top: none;
     margin-top: 0;
   }

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -209,25 +209,28 @@ export default function OpeningPeriodForm({
           </div>
         </section>
         <section className="form-section time-span-group">
-          <div className="time-span-list-container">
-            <h3 className="opening-period-section-title">Aukioloajat</h3>
+          <h3 className="opening-period-section-title">Aukioloajat</h3>
+          <ul
+            className="opening-period-time-span-list"
+            data-test="time-span-list">
             {fields.map(
               (
                 item: Partial<ArrayField<Record<string, TimeSpanFormFormat>>>,
                 index
               ) => (
-                <TimeSpan
-                  item={item}
-                  resourceStateOptions={resourceStateOptions}
-                  setValue={setValue}
-                  register={register}
-                  key={`time-span-${item.id || index}`}
-                  index={index}
-                  remove={remove}
-                />
+                <li key={`time-span-${item.id || index}`}>
+                  <TimeSpan
+                    item={item}
+                    resourceStateOptions={resourceStateOptions}
+                    setValue={setValue}
+                    register={register}
+                    index={index}
+                    remove={remove}
+                  />
+                </li>
               )
             )}
-          </div>
+          </ul>
           <SecondaryButton
             dataTest="add-new-time-span-button"
             onClick={(): void => append({})}

--- a/src/opening-period/form/form-helpers/form-helpers.test.ts
+++ b/src/opening-period/form/form-helpers/form-helpers.test.ts
@@ -33,13 +33,13 @@ const apiTimeSpanA: TimeSpan = {
 };
 
 const apiTimeSpanB: TimeSpan = {
-  id: 1234,
+  id: 2345,
   name: { en: null, fi: null, sv: null },
-  description: { en: null, fi: 'description text A', sv: null },
+  description: { en: null, fi: null, sv: null },
   end_time: '18:00:00',
   resource_state: ResourceState.SELF_SERVICE,
   start_time: '10:00:00',
-  weekdays: [6, 7],
+  weekdays: [],
   created: '2020-12-16T12:21:37.255923+02:00',
   modified: '2020-12-16T12:21:37.255923+02:00',
   full_day: false,
@@ -75,6 +75,19 @@ describe('opening-period form-helpers', () => {
       ]);
     });
 
+    it('should provide default values for form-format (ui-format)', () => {
+      expect(formatApiTimeSpansToFormFormat([apiTimeSpanB])).toEqual([
+        {
+          id: 2345,
+          description: '',
+          endTime: '18:00',
+          resourceState: ResourceState.SELF_SERVICE,
+          startTime: '10:00',
+          weekdays: [false, false, false, false, false, false, false],
+        },
+      ]);
+    });
+
     it('should sort time-spans by weekdays (spans with selected days in the beginning of the week are listed higher)', () => {
       const [
         formTimeSpanFirst,
@@ -97,8 +110,8 @@ describe('opening-period form-helpers', () => {
         false,
         false,
         false,
-        true,
-        true,
+        false,
+        false,
       ]);
     });
   });

--- a/src/opening-period/form/form-helpers/form-helpers.ts
+++ b/src/opening-period/form/form-helpers/form-helpers.ts
@@ -10,7 +10,7 @@ export function formatTimeSpansToApiFormat(
   return timeSpans.map((timeSpan) => {
     return {
       description: {
-        fi: timeSpan?.description,
+        fi: timeSpan?.description ?? '',
         sv: null,
         en: null,
       },

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
@@ -273,11 +273,14 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
   });
 
   it('should show error notification if loading resource info on page load fails', async () => {
+    const error: Error = new Error('Failed to load a resource');
+    const errorConsoleSpy = jest
+      .spyOn(global.console, 'error')
+      .mockImplementationOnce((e) => e);
+
     jest
       .spyOn(api, 'getResource')
-      .mockImplementation(() =>
-        Promise.reject(new Error('Failed to load a resource'))
-      );
+      .mockImplementation(() => Promise.reject(error));
 
     render(<CreateNewOpeningPeriodPage resourceId="tprek:8100" />);
 
@@ -285,6 +288,10 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
       const errorHeading = await screen.getByRole('heading', { level: 1 });
       const notificationText = await screen.findByTestId(
         'error-retrieving-resource-info'
+      );
+      expect(errorConsoleSpy).toHaveBeenCalledWith(
+        'Add date-period - data initialization error:',
+        error
       );
       expect(errorHeading).toHaveTextContent('Virhe');
       expect(notificationText).toBeInTheDocument();
@@ -292,11 +299,14 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
   });
 
   it('should show error notification if loading date period form options fails', async () => {
+    const error: Error = new Error('Failed to load date period form options');
+    const errorConsoleSpy = jest
+      .spyOn(global.console, 'error')
+      .mockImplementationOnce((e) => e);
+
     jest
       .spyOn(api, 'getDatePeriodFormOptions')
-      .mockImplementation(() =>
-        Promise.reject(new Error('Failed to load date period form options'))
-      );
+      .mockImplementation(() => Promise.reject(error));
 
     render(<CreateNewOpeningPeriodPage resourceId="tprek:8100" />);
 
@@ -305,12 +315,21 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
       const notificationText = await screen.findByTestId(
         'error-retrieving-resource-info'
       );
+      expect(errorConsoleSpy).toHaveBeenCalledWith(
+        'Add date-period - data initialization error:',
+        error
+      );
       expect(errorHeading).toHaveTextContent('Virhe');
       expect(notificationText).toBeInTheDocument();
     });
   });
 
   it('should show error notification when form submit fails api side', async () => {
+    const error: Error = new Error('ApiError for test purpose');
+    const errorConsoleSpy = jest
+      .spyOn(global.console, 'error')
+      .mockImplementationOnce((e) => e);
+
     jest
       .spyOn(api, 'postDatePeriod')
       .mockImplementation(() =>
@@ -367,6 +386,7 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
     });
 
     await act(async () => {
+      expect(errorConsoleSpy).toHaveBeenCalledWith(error);
       expect(
         await screen.findByTestId('opening-period-form-error')
       ).toBeInTheDocument();

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.tsx
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.tsx
@@ -45,7 +45,7 @@ export default function CreateNewOpeningPeriodPage({
         setHasDataLoadingError(true);
         setIsLoading(false);
         // eslint-disable-next-line no-console
-        console.error('Add dateperiod - data initialization error:', e);
+        console.error('Add date-period - data initialization error:', e);
       }
     };
 

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -300,7 +300,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
   });
 
   it('should show error notification when loading date period fails', async () => {
-    const error: Error = new Error('Failed to load date period form options');
+    const error: Error = new Error('Failed to load date period');
     const errorConsoleSpy = jest
       .spyOn(global.console, 'error')
       .mockImplementationOnce((cb) => cb);

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -191,41 +191,65 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
     });
 
     await act(async () => {
+      const firstTimeSpan = container.querySelector(
+        '[data-test="time-span-list"] > li:first-child'
+      );
+
+      if (!firstTimeSpan) {
+        throw new Error(
+          'Something went wrong in first time-span rendering of EditOpeningPeriodPage'
+        );
+      }
+
       expect(
-        container.querySelector('[data-test="weekdays-monday-0-checkbox"]')
+        firstTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-monday"]'
+        )
       ).toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-tuesday-0-checkbox"]')
+        firstTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-tuesday"]'
+        )
       ).toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-wednesday-0-checkbox"]')
+        firstTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-wednesday"]'
+        )
       ).toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-thursday-0-checkbox"]')
+        firstTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-thursday"]'
+        )
       ).toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-friday-0-checkbox"]')
+        firstTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-friday"]'
+        )
       ).toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-saturday-0-checkbox"]')
+        firstTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-saturday"]'
+        )
       ).not.toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-sunday-0-checkbox"]')
+        firstTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-sunday"]'
+        )
       ).not.toBeChecked();
 
       expect(
-        container.querySelector('#time-span-state-id-0-toggle-button')
+        firstTimeSpan.querySelector('#time-span-state-id-0-toggle-button')
       ).toHaveTextContent('Open');
 
-      expect(container.querySelector('#time-span-0-description')).toHaveValue(
-        'Arkena ovet menevät kiinni puolta tuntia aiemmin'
-      );
+      expect(
+        firstTimeSpan.querySelector('#time-span-0-description')
+      ).toHaveValue('Arkena ovet menevät kiinni puolta tuntia aiemmin');
     });
   });
 
@@ -245,41 +269,64 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
     });
 
     await act(async () => {
+      const lastTimeSpan = container.querySelector(
+        '[data-test="time-span-list"] > li:last-child'
+      );
+
+      if (!lastTimeSpan) {
+        throw new Error(
+          'Something went wrong in last time-span rendering of EditOpeningPeriodPage'
+        );
+      }
       expect(
-        container.querySelector('[data-test="weekdays-monday-1-checkbox"]')
+        lastTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-monday"]'
+        )
       ).not.toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-tuesday-1-checkbox"]')
+        lastTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-tuesday"]'
+        )
       ).not.toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-wednesday-1-checkbox"]')
+        lastTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-wednesday"]'
+        )
       ).not.toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-thursday-1-checkbox"]')
+        lastTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-thursday"]'
+        )
       ).not.toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-friday-1-checkbox"]')
+        lastTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-friday"]'
+        )
       ).not.toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-saturday-1-checkbox"]')
+        lastTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-saturday"]'
+        )
       ).toBeChecked();
 
       expect(
-        container.querySelector('[data-test="weekdays-sunday-1-checkbox"]')
+        lastTimeSpan.querySelector(
+          '[type="checkbox"][data-test^="weekdays-sunday"]'
+        )
       ).toBeChecked();
 
       expect(
-        container.querySelector('#time-span-state-id-1-toggle-button')
+        lastTimeSpan.querySelector('#time-span-state-id-1-toggle-button')
       ).toHaveTextContent('Self service');
 
-      expect(container.querySelector('#time-span-1-description')).toHaveValue(
-        'Viikonloppuna ovet menevät kiinni tuntia aiemmin'
-      );
+      expect(
+        lastTimeSpan.querySelector('#time-span-1-description')
+      ).toHaveValue('Viikonloppuna ovet menevät kiinni tuntia aiemmin');
     });
   });
 

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -151,7 +151,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
 
       if (!container) {
         throw new Error(
-          'Something went wrong in rendering of CreateNewOpeningPeriodPage'
+          'Something went wrong in rendering of EditOpeningPeriodPage'
         );
       }
     });
@@ -185,7 +185,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
 
       if (!container) {
         throw new Error(
-          'Something went wrong in rendering of CreateNewOpeningPeriodPage'
+          'Something went wrong in rendering of EditOpeningPeriodPage'
         );
       }
     });
@@ -239,7 +239,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
 
       if (!container) {
         throw new Error(
-          'Something went wrong in rendering of CreateNewOpeningPeriodPage'
+          'Something went wrong in rendering of EditOpeningPeriodPage'
         );
       }
     });

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -175,7 +175,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
     });
   });
 
-  it('should render first the time-span when it has the weekdays in the beginning of the week', async () => {
+  it('should render first the time-span which has the weekdays in the beginning of the week', async () => {
     let container: HTMLElement;
 
     await act(async () => {

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -354,9 +354,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
 
     jest
       .spyOn(api, 'getDatePeriod')
-      .mockImplementation(() =>
-        Promise.reject(new Error('Failed to load date period form options'))
-      );
+      .mockImplementation(() => Promise.reject(error));
 
     render(<EditOpeningPeriodPage resourceId="tprek:8100" datePeriodId="1" />);
 

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -62,9 +62,6 @@ const testResource: Resource = {
 
 const testDatePeriod: DatePeriod = {
   id: 1,
-  created: '2020-11-20',
-  modified: '2020-11-20',
-  is_removed: false,
   name: { fi: 'test opening period', sv: '', en: '' },
   description: { fi: 'test opening period description', sv: '', en: '' },
   start_date: '2020-12-18',

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -1,0 +1,332 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { render, screen } from '@testing-library/react';
+import {
+  DatePeriod,
+  DatePeriodOptions,
+  Resource,
+  ResourceState,
+} from '../../common/lib/types';
+import api from '../../common/utils/api/api';
+import EditOpeningPeriodPage from './EditOpeningPeriodPage';
+
+const testDatePeriodOptions: DatePeriodOptions = {
+  actions: {
+    POST: {
+      resource_state: {
+        choices: [
+          {
+            value: 'open',
+            display_name: 'Open',
+          },
+          {
+            value: 'closed',
+            display_name: {
+              fi: 'Suljettu',
+              sv: null,
+              en: null,
+            },
+          },
+          {
+            value: 'self_service',
+            display_name: 'Self service',
+          },
+        ],
+      },
+    },
+  },
+};
+
+const testResource: Resource = {
+  id: 1186,
+  name: {
+    fi: 'Test resource name in finnish',
+    sv: 'Test resource name in swedish',
+    en: 'Test resource name in english',
+  },
+  address: {
+    fi: 'Test address in finnish',
+    sv: 'Test address in swedish',
+    en: 'Test address in english',
+  },
+  description: {
+    fi: 'Test description in finnish',
+    sv: 'Test description in swedish',
+    en: 'Test description in english',
+  },
+  extra_data: {
+    citizen_url: 'kansalaisen puolen url',
+    admin_url: 'admin puolen url',
+  },
+};
+
+const testDatePeriod: DatePeriod = {
+  id: 1,
+  created: '2020-11-20',
+  modified: '2020-11-20',
+  is_removed: false,
+  name: { fi: 'test opening period', sv: '', en: '' },
+  description: { fi: 'test opening period description', sv: '', en: '' },
+  start_date: '2020-12-18',
+  end_date: '2021-01-18',
+  resource_state: ResourceState.OPEN,
+  override: false,
+  resource: 1,
+  time_span_groups: [
+    {
+      id: 2,
+      period: 1,
+      rules: [],
+      time_spans: [
+        {
+          created: '2020-12-18T10:00:00.000000+02:00',
+          description: {
+            fi: 'Viikonloppuna ovet menevät kiinni tuntia aiemmin',
+            sv: null,
+            en: null,
+          },
+          end_time: '17:00:00',
+          full_day: false,
+          group: 1225,
+          id: 2637,
+          modified: '2020-12-18T10:00:00.000000+02:00',
+          name: {
+            fi: null,
+            sv: null,
+            en: null,
+          },
+          resource_state: ResourceState.SELF_SERVICE,
+          start_time: '12:00:00',
+          weekdays: [6, 7],
+        },
+        {
+          created: '2020-12-18T10:00:00.000000+02:00',
+          description: {
+            fi: 'Arkena ovet menevät kiinni puolta tuntia aiemmin',
+            sv: null,
+            en: null,
+          },
+          end_time: '18:00:00',
+          full_day: false,
+          group: 1225,
+          id: 2636,
+          modified: '2020-12-18T10:00:00.000000+02:00',
+          name: {
+            fi: null,
+            sv: null,
+            en: null,
+          },
+          resource_state: ResourceState.OPEN,
+          start_time: '10:00:00',
+          weekdays: [1, 2, 3, 4, 5],
+        },
+      ],
+    },
+  ],
+};
+
+describe(`<EditNewOpeningPeriodPage />`, () => {
+  beforeEach(() => {
+    jest
+      .spyOn(api, 'getResource')
+      .mockImplementation(() => Promise.resolve(testResource));
+
+    jest
+      .spyOn(api, 'getDatePeriodFormOptions')
+      .mockImplementation(() => Promise.resolve(testDatePeriodOptions));
+
+    jest
+      .spyOn(api, 'getDatePeriod')
+      .mockImplementation(() => Promise.resolve(testDatePeriod));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render basic date-period data', async () => {
+    let container: HTMLElement;
+
+    await act(async () => {
+      container = render(
+        <EditOpeningPeriodPage resourceId="tprek:8100" datePeriodId="1" />
+      ).container;
+
+      if (!container) {
+        throw new Error(
+          'Something went wrong in rendering of CreateNewOpeningPeriodPage'
+        );
+      }
+    });
+
+    await act(async () => {
+      // Check info data
+      expect(
+        container.querySelector('[data-test="openingPeriodTitle"]')
+      ).toHaveValue(testDatePeriod.name.fi);
+
+      expect(
+        container.querySelector('#openingPeriodOptionalDescription')
+      ).toHaveValue(testDatePeriod.description.fi);
+
+      expect(container.querySelector('#openingPeriodBeginDate')).toHaveValue(
+        '18.12.2020'
+      );
+      expect(container.querySelector('#openingPeriodEndDate')).toHaveValue(
+        '18.01.2021'
+      );
+    });
+  });
+
+  it('should render first the time-span with weekdays in the beginning of the week', async () => {
+    let container: HTMLElement;
+
+    await act(async () => {
+      container = render(
+        <EditOpeningPeriodPage resourceId="tprek:8100" datePeriodId="1" />
+      ).container;
+
+      if (!container) {
+        throw new Error(
+          'Something went wrong in rendering of CreateNewOpeningPeriodPage'
+        );
+      }
+    });
+
+    await act(async () => {
+      expect(
+        container.querySelector('[data-test="weekdays-monday-0-checkbox"]')
+      ).toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-tuesday-0-checkbox"]')
+      ).toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-wednesday-0-checkbox"]')
+      ).toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-thursday-0-checkbox"]')
+      ).toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-friday-0-checkbox"]')
+      ).toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-saturday-0-checkbox"]')
+      ).not.toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-sunday-0-checkbox"]')
+      ).not.toBeChecked();
+
+      expect(
+        container.querySelector('#time-span-state-id-0-toggle-button')
+      ).toHaveTextContent('Open');
+
+      expect(container.querySelector('#time-span-0-description')).toHaveValue(
+        'Arkena ovet menevät kiinni puolta tuntia aiemmin'
+      );
+    });
+  });
+
+  it('should render last the time-span with weekdays in the end of the week', async () => {
+    let container: HTMLElement;
+
+    await act(async () => {
+      container = render(
+        <EditOpeningPeriodPage resourceId="tprek:8100" datePeriodId="1" />
+      ).container;
+
+      if (!container) {
+        throw new Error(
+          'Something went wrong in rendering of CreateNewOpeningPeriodPage'
+        );
+      }
+    });
+
+    await act(async () => {
+      expect(
+        container.querySelector('[data-test="weekdays-monday-1-checkbox"]')
+      ).not.toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-tuesday-1-checkbox"]')
+      ).not.toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-wednesday-1-checkbox"]')
+      ).not.toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-thursday-1-checkbox"]')
+      ).not.toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-friday-1-checkbox"]')
+      ).not.toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-saturday-1-checkbox"]')
+      ).toBeChecked();
+
+      expect(
+        container.querySelector('[data-test="weekdays-sunday-1-checkbox"]')
+      ).toBeChecked();
+
+      expect(
+        container.querySelector('#time-span-state-id-1-toggle-button')
+      ).toHaveTextContent('Self service');
+
+      expect(container.querySelector('#time-span-1-description')).toHaveValue(
+        'Viikonloppuna ovet menevät kiinni tuntia aiemmin'
+      );
+    });
+  });
+
+  it('should show loading indicator while loading date period', async () => {
+    jest.spyOn(api, 'getDatePeriod').mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return new Promise(() => {});
+    });
+
+    render(<EditOpeningPeriodPage resourceId="tprek:8100" datePeriodId="1" />);
+
+    await act(async () => {
+      expect(await screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Aukiolojakson muokkaus'
+      );
+      expect(await screen.getByText('Sivua ladataan...')).toBeInTheDocument();
+    });
+  });
+
+  it('should show error notification if loading date period fails', async () => {
+    const error: Error = new Error('Failed to load date period form options');
+    const errorConsoleSpy = jest
+      .spyOn(global.console, 'error')
+      .mockImplementationOnce((cb) => cb);
+
+    jest
+      .spyOn(api, 'getDatePeriod')
+      .mockImplementation(() =>
+        Promise.reject(new Error('Failed to load date period form options'))
+      );
+
+    render(<EditOpeningPeriodPage resourceId="tprek:8100" datePeriodId="1" />);
+
+    await act(async () => {
+      const errorHeading = await screen.getByRole('heading', { level: 1 });
+      const notificationText = await screen.findByTestId(
+        'error-retrieving-resource-info'
+      );
+      expect(errorConsoleSpy).toHaveBeenCalledWith(
+        'Edit date-period - data initialization error:',
+        error
+      );
+      expect(errorHeading).toHaveTextContent('Virhe');
+      expect(notificationText).toBeInTheDocument();
+    });
+  });
+});

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -178,7 +178,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
     });
   });
 
-  it('should render first the time-span with weekdays in the beginning of the week', async () => {
+  it('should render first the time-span when it has the weekdays in the beginning of the week', async () => {
     let container: HTMLElement;
 
     await act(async () => {
@@ -232,7 +232,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
     });
   });
 
-  it('should render last the time-span with weekdays in the end of the week', async () => {
+  it('should render last the time-span when it has the weekdays in the end of the week', async () => {
     let container: HTMLElement;
 
     await act(async () => {
@@ -302,7 +302,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
     });
   });
 
-  it('should show error notification if loading date period fails', async () => {
+  it('should show error notification when loading date period fails', async () => {
     const error: Error = new Error('Failed to load date period form options');
     const errorConsoleSpy = jest
       .spyOn(global.console, 'error')

--- a/src/opening-period/page/EditOpeningPeriodPage.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.tsx
@@ -55,7 +55,7 @@ export default function EditOpeningPeriodPage({
         setHasDataLoadingError(true);
         setIsLoading(false);
         // eslint-disable-next-line no-console
-        console.error('Edit dateperiod - data initialization error:', e);
+        console.error('Edit date-period - data initialization error:', e);
       }
     };
 

--- a/src/opening-period/page/EditOpeningPeriodPage.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.tsx
@@ -67,6 +67,7 @@ export default function EditOpeningPeriodPage({
       <>
         <h1 className="resource-info-title">Virhe</h1>
         <Notification
+          dataTestId="error-retrieving-resource-info"
           label="Toimipisteen tietoja ei saatu ladattua."
           type="error">
           Tarkista toimipisteen id tai aukiolojakson id.
@@ -79,6 +80,7 @@ export default function EditOpeningPeriodPage({
     return (
       <>
         <h1 className="resource-info-title">Aukiolojakson muokkaus</h1>
+        <p>Sivua ladataan...</p>
       </>
     );
   }

--- a/src/opening-period/time-span/TimeSpan.scss
+++ b/src/opening-period/time-span/TimeSpan.scss
@@ -41,8 +41,3 @@
   justify-content: space-between;
   align-items: flex-end;
 }
-
-.time-span-container {
-  border-top: var(--spacing-4-xs) solid var(--primary-color);
-  margin-top: $spacing-2-xl;
-}

--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -100,7 +100,7 @@ export default function TimeSpan({
             id={`timeSpans[${index}].description`}
             name={`timeSpans[${index}].description`}
             className="time-span-description"
-            defaultValue={`${item.description || ''}`}
+            defaultValue={`${item.description}`}
             label="Kuvaus"
             placeholder="Valinnainen lyhyt kuvaus esim. naisten vuoro"
           />

--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -97,7 +97,7 @@ export default function TimeSpan({
         <div className="time-span-description-container">
           <TextInput
             ref={register()}
-            id={`timeSpans[${index}].description`}
+            id={`time-span-${index}-description`}
             name={`timeSpans[${index}].description`}
             className="time-span-description"
             defaultValue={`${item.description}`}


### PR DESCRIPTION
- Supress expected console.errors in CreateOpeningPeriodPage-tests
- Fix time-span description default value issue -- api value was ignored
- Use `<ul>`-element for time-span listing 
- Add tests for EditOpeningPage