### PR TITLE
Fix time-span type-dropdown CSS-bug

### DIFF
--- a/src/opening-period/form/OpeningPeriodForm.scss
+++ b/src/opening-period/form/OpeningPeriodForm.scss
@@ -48,15 +48,15 @@
   margin: 0;
   padding: 0 0 var(--spacing-layout-xs);
   position: relative;
+}
 
-  li {
-    list-style: none;
-    border-top: var(--spacing-4-xs) solid var(--primary-color);
-    margin: $spacing-2-xl 0 0;
-    padding: 0;
-  }
+.opening-period-time-span-list-item {
+  list-style: none;
+  border-top: var(--spacing-4-xs) solid var(--primary-color);
+  margin: $spacing-2-xl 0 0;
+  padding: 0;
 
-  > li:first-child {
+  &:first-child {
     border-top: none;
     margin-top: 0;
   }

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -218,7 +218,9 @@ export default function OpeningPeriodForm({
                 item: Partial<ArrayField<Record<string, TimeSpanFormFormat>>>,
                 index
               ) => (
-                <li key={`time-span-${item.id || index}`}>
+                <li
+                  className="opening-period-time-span-list-item"
+                  key={`time-span-${item.id || index}`}>
                   <TimeSpan
                     item={item}
                     resourceStateOptions={resourceStateOptions}


### PR DESCRIPTION
- Fixed issue with to generic CSS-declaration, caused styles leak

Before:
<img width="619" alt="Näyttökuva 2020-12-21 kello 13 42 13" src="https://user-images.githubusercontent.com/1610860/102773851-94765000-4392-11eb-8222-dced9e5d303e.png">


After:
<img width="669" alt="Näyttökuva 2020-12-21 kello 13 41 59" src="https://user-images.githubusercontent.com/1610860/102773868-993b0400-4392-11eb-9378-ab84a2b26a8c.png">
