### PR TITLE
Fix dash-placement between date-inputs

### DIFF
--- a/src/opening-period/form/OpeningPeriodForm.scss
+++ b/src/opening-period/form/OpeningPeriodForm.scss
@@ -23,10 +23,8 @@
 }
 
 .dash-between-begin-and-end-date {
-  margin-bottom: -35px;
-  margin-left: 10px;
-  margin-right: 10px;
   font-family: HelsinkiGrotesk-Bold, Arial, sans-serif;
+  margin: 2rem 10px 0;
 }
 
 .opening-period-final-action-row-container {


### PR DESCRIPTION
Before: 
<img width="512" alt="Näyttökuva 2020-12-21 kello 14 01 29" src="https://user-images.githubusercontent.com/1610860/102775216-16677880-4395-11eb-8bc1-a2150b67aeff.png">



After:
<img width="479" alt="Näyttökuva 2020-12-21 kello 14 01 13" src="https://user-images.githubusercontent.com/1610860/102775184-09e32000-4395-11eb-90fe-324e4dfef55d.png">
