### PR TITLE
Fix time-span's description default value

### DIFF
--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -100,7 +100,7 @@ export default function TimeSpan({
             id={`time-span-${index}-description`}
             name={`timeSpans[${index}].description`}
             className="time-span-description"
-            defaultValue={`${item.description}`}
+            defaultValue={`${item.description || ''}`}
             label="Kuvaus"
             placeholder="Valinnainen lyhyt kuvaus esim. naisten vuoro"
           />


### PR DESCRIPTION
Before:
<img width="1075" alt="Näyttökuva 2020-12-21 kello 14 18 24" src="https://user-images.githubusercontent.com/1610860/102776446-69dac600-4397-11eb-8aff-d152c05bc3e3.png">

After:
<img width="777" alt="Näyttökuva 2020-12-21 kello 14 18 01" src="https://user-images.githubusercontent.com/1610860/102776465-6e9f7a00-4397-11eb-8f26-abf9244d2ca4.png">
