### PR TITLE
Hauki 280 opening type edit fix

### DIFF
--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -57,7 +57,7 @@ export type FormWeekdays = [
 ];
 
 export type TimeSpanFormFormat = {
-  id?: number;
+  id?: string;
   description: string;
   endTime: string;
   startTime: string;

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -124,7 +124,7 @@ async function apiPost<T>({
   });
 }
 
-async function apiPut<T>({
+async function apiPatch<T>({
   path,
   data = {},
 }: PutRequestParameters): Promise<T> {
@@ -133,7 +133,7 @@ async function apiPut<T>({
     headers: {
       'Content-Type': 'application/json',
     },
-    method: 'put',
+    method: 'patch',
     data,
     validateStatus,
   });
@@ -210,8 +210,8 @@ export default {
       data: datePeriod,
     }),
 
-  putDatePeriod: (datePeriod: DatePeriod): Promise<DatePeriod> =>
-    apiPut<DatePeriod>({
+  patchDatePeriod: (datePeriod: DatePeriod): Promise<DatePeriod> =>
+    apiPatch<DatePeriod>({
       path: `${datePeriodBasePath}/${datePeriod.id}`,
       data: datePeriod,
     }),

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -102,7 +102,7 @@ export default function OpeningPeriodForm({
     timeSpans: spans,
   };
 
-  const { register, handleSubmit, errors, control, watch } = useForm<
+  const { register, handleSubmit, errors, control } = useForm<
     OpeningPeriodFormData
   >({
     mode: 'all',

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -8,6 +8,7 @@ import {
   ResourceStateApiOption,
   ResourceStateOption,
   TimeSpanFormFormat,
+  TimeSpanGroup,
 } from '../../common/lib/types';
 import { transformDateToApiFormat } from '../../common/utils/date-time/format';
 import Datepicker from '../../components/datepicker/Datepicker';
@@ -79,12 +80,12 @@ export default function OpeningPeriodForm({
     resourceStateOptionsInApiFormat
   );
 
+  const firstTimeSpanGroup: TimeSpanGroup | undefined =
+    datePeriod?.time_span_groups[0];
+
   const spans: TimeSpanFormFormat[] | {}[] =
-    datePeriod?.time_span_groups[0] &&
-    datePeriod?.time_span_groups[0].time_spans
-      ? formatApiTimeSpansToFormFormat(
-          datePeriod?.time_span_groups[0].time_spans
-        )
+    firstTimeSpanGroup && firstTimeSpanGroup.time_spans
+      ? formatApiTimeSpansToFormFormat(firstTimeSpanGroup.time_spans)
       : [{}];
 
   const [periodBeginDate, setPeriodBeginDate] = useState<Date | null>(
@@ -144,6 +145,8 @@ export default function OpeningPeriodForm({
         override: datePeriod?.override || false,
         time_span_groups: [
           {
+            id: firstTimeSpanGroup?.id,
+            period: firstTimeSpanGroup?.period,
             time_spans: formatTimeSpansToApiFormat(validTimeSpans || []),
             rules: [],
           },

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -102,7 +102,7 @@ export default function OpeningPeriodForm({
     timeSpans: spans,
   };
 
-  const { register, handleSubmit, errors, control, setValue } = useForm<
+  const { register, handleSubmit, errors, control, watch } = useForm<
     OpeningPeriodFormData
   >({
     mode: 'all',
@@ -224,7 +224,7 @@ export default function OpeningPeriodForm({
                   <TimeSpan
                     item={item}
                     resourceStateOptions={resourceStateOptions}
-                    setValue={setValue}
+                    control={control}
                     register={register}
                     index={index}
                     remove={remove}

--- a/src/opening-period/form/form-helpers/form-helpers.test.ts
+++ b/src/opening-period/form/form-helpers/form-helpers.test.ts
@@ -65,7 +65,7 @@ describe('opening-period form-helpers', () => {
     it('should return time-spans in form-format (ui-format)', () => {
       expect(formatApiTimeSpansToFormFormat([apiTimeSpanA])).toEqual([
         {
-          id: 1234,
+          id: '1234',
           description: 'description text A',
           endTime: '18:00',
           resourceState: ResourceState.OPEN,
@@ -78,7 +78,7 @@ describe('opening-period form-helpers', () => {
     it('should provide default values for form-format (ui-format)', () => {
       expect(formatApiTimeSpansToFormFormat([apiTimeSpanB])).toEqual([
         {
-          id: 2345,
+          id: '2345',
           description: '',
           endTime: '18:00',
           resourceState: ResourceState.SELF_SERVICE,

--- a/src/opening-period/form/form-helpers/form-helpers.ts
+++ b/src/opening-period/form/form-helpers/form-helpers.ts
@@ -9,6 +9,7 @@ export function formatTimeSpansToApiFormat(
 ): TimeSpanApiFormat[] {
   return timeSpans.map((timeSpan) => {
     return {
+      id: timeSpan.id ? parseInt(timeSpan.id, 10) : undefined,
       description: {
         fi: timeSpan?.description ?? '',
         sv: null,
@@ -52,7 +53,7 @@ export function formatApiTimeSpansToFormFormat(
         );
 
       return {
-        id: apiTimeSpan.id,
+        id: apiTimeSpan.id ? apiTimeSpan.id.toString() : undefined,
         description: apiTimeSpan.description?.fi || '',
         startTime: apiTimeSpan.start_time
           ? dropMilliseconds(apiTimeSpan.start_time)

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -363,8 +363,8 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
     let container: HTMLElement;
     let lastTimeSpan: HTMLElement | null;
 
-    const putDatePeriodSpy = jest
-      .spyOn(api, 'putDatePeriod')
+    const patchDatePeriodSpy = jest
+      .spyOn(api, 'patchDatePeriod')
       .mockImplementationOnce(() => Promise.resolve(testDatePeriod));
 
     await act(async () => {
@@ -432,7 +432,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
       );
       const rest = timeSpans.filter(({ id }) => id !== weekendTimeSpanId);
 
-      expect(putDatePeriodSpy).toHaveBeenCalledWith(
+      expect(patchDatePeriodSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           time_span_groups: [
             {

--- a/src/opening-period/page/EditOpeningPeriodPage.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.tsx
@@ -33,7 +33,7 @@ export default function EditOpeningPeriodPage({
   );
 
   const submitFn = (updatedDatePeriod: DatePeriod): Promise<DatePeriod> =>
-    api.putDatePeriod(updatedDatePeriod);
+    api.patchDatePeriod(updatedDatePeriod);
 
   useEffect((): void => {
     const fetchData = async (): Promise<void> => {

--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { ArrayField } from 'react-hook-form';
+import React from 'react';
+import { ArrayField, Controller, Control } from 'react-hook-form';
 import { Button as HDSButton, IconTrash, Select, TextInput } from 'hds-react';
 import Weekdays from './Weekdays';
 import './TimeSpan.scss';
@@ -14,20 +14,16 @@ export default function TimeSpan({
   index,
   remove,
   register,
-  setValue,
+  control,
   resourceStateOptions,
 }: {
   item: Partial<ArrayField<Record<string, TimeSpanFormFormat>>>;
   index: number;
   remove: Function;
   register: Function;
-  setValue: Function;
+  control: Control;
   resourceStateOptions: ResourceStateOption[];
 }): JSX.Element {
-  useEffect(() => {
-    register({ name: `timeSpans[${index}].resourceState` });
-  });
-
   return (
     <div data-test={`time-span-${index}`} className="time-span-container">
       <div className="time-span-first-header-row">
@@ -77,19 +73,26 @@ export default function TimeSpan({
       </div>
       <div className="form-control">
         <div className="time-span-state-container">
-          <Select
-            id={`time-span-state-id-${index}`}
-            onChange={(selection: { label: string; value: string }): void => {
-              setValue(`timeSpans[${index}].resourceState`, selection.value);
-            }}
-            className="time-span-state"
-            defaultValue={resourceStateOptions.find(
-              ({ value }) =>
-                value === ((item.resourceState as unknown) as string)
+          <Controller
+            control={control}
+            name={`timeSpans[${index}].resourceState`}
+            defaultValue={`${item.resourceState}`}
+            render={({ onChange, value }): JSX.Element => (
+              <Select
+                id={`time-span-state-id-${index}`}
+                onChange={(selected: ResourceStateOption): void => {
+                  onChange(selected.value);
+                }}
+                className="time-span-state"
+                defaultValue={resourceStateOptions.find(
+                  (option: ResourceStateOption): boolean =>
+                    option.value === value
+                )}
+                options={resourceStateOptions}
+                label="Tyyppi"
+                placeholder="Valitse tyyppi"
+              />
             )}
-            options={resourceStateOptions}
-            label="Tyyppi"
-            placeholder="Valitse tyyppi"
           />
         </div>
       </div>

--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -26,6 +26,12 @@ export default function TimeSpan({
 }): JSX.Element {
   return (
     <div data-test={`time-span-${index}`} className="time-span-container">
+      <input
+        type="hidden"
+        name={`timeSpans[${index}].id`}
+        defaultValue={item.id}
+        ref={register()}
+      />
       <div className="time-span-first-header-row">
         <Weekdays index={index} item={item} register={register} />
         <HDSButton


### PR DESCRIPTION
- Fix edit date-period bug where all the time-spans' unchanged type data is lost on save. Our form library, React-form-hook, could not register initial values (every value has to be registered) because HDS Dropdown-component does not support ref-attribute. Instead, we need to use the React-hook-form's Controller wrapper component to circumvent the problem: https://react-hook-form.com/get-started/#IntegratingwithUIlibraries
- Pass timespans' ids and the timespangroup id and period-id on save 

- Use PATCH-method when updating date-period to prevent data inconsistency issues