### PR TITLE
Hauki 369 add validations and restrictions to date-period basic data

### DIFF
--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -76,9 +76,14 @@ export type InputOption = {
   value: string;
 };
 
+export type TextFieldConfig = {
+  max_length?: number;
+};
+
 export type DatePeriodOptions = {
   actions: {
     POST: {
+      name: TextFieldConfig;
       resource_state: {
         choices: ApiChoice[];
       };
@@ -118,6 +123,7 @@ export type UiRuleConfig = {
 };
 
 export type UiDatePeriodConfig = {
+  name: TextFieldConfig;
   resourceState: UiFieldConfig;
   timeSpanGroup: {
     rule: UiRuleConfig;

--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -112,19 +112,19 @@ export type DatePeriodOptions = {
   };
 };
 
-export type UiFieldConfig = {
+export type UiOptionsFieldConfig = {
   options: InputOption[];
 };
 
 export type UiRuleConfig = {
-  context: UiFieldConfig;
-  subject: UiFieldConfig;
-  frequencyModifier: UiFieldConfig;
+  context: UiOptionsFieldConfig;
+  subject: UiOptionsFieldConfig;
+  frequencyModifier: UiOptionsFieldConfig;
 };
 
 export type UiDatePeriodConfig = {
   name: TextFieldConfig;
-  resourceState: UiFieldConfig;
+  resourceState: UiOptionsFieldConfig;
   timeSpanGroup: {
     rule: UiRuleConfig;
   };

--- a/src/common/utils/api/api.test.ts
+++ b/src/common/utils/api/api.test.ts
@@ -211,7 +211,7 @@ describe('apiRequest', () => {
       };
 
       mockedAxios.request.mockResolvedValue({ data: datePeriodOptions });
-      const response = await api.getDatePeriodFormOptions();
+      const response = await api.getDatePeriodFormConfig();
       expect(response).toEqual({
         resourceState: {
           options: [

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -232,15 +232,16 @@ export default {
       path: `${datePeriodBasePath}`,
     });
 
-    const resourceStateChoices = response.actions.POST.resource_state.choices;
+    const configResponse = response.actions.POST;
+
+    const resourceStateChoices = configResponse.resource_state.choices;
 
     const resourceStateOptions: InputOption[] = resourceStateChoices.map(
       convertApiChoiceToInputOption
     );
 
     const timeSpanGroupOptions =
-      response.actions.POST.time_span_groups.child.children.rules.child
-        .children;
+      configResponse.time_span_groups.child.children.rules.child.children;
 
     const ruleContextOptions: InputOption[] = timeSpanGroupOptions.context.choices.map(
       convertApiChoiceToInputOption
@@ -255,6 +256,7 @@ export default {
     );
 
     return {
+      name: configResponse.name,
       resourceState: {
         options: resourceStateOptions,
       },

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -227,7 +227,7 @@ export default {
       path: `${datePeriodBasePath}/${datePeriodId}`,
     }),
 
-  getDatePeriodFormOptions: async (): Promise<UiDatePeriodConfig> => {
+  getDatePeriodFormConfig: async (): Promise<UiDatePeriodConfig> => {
     const response = await apiOptions<DatePeriodOptions>({
       path: `${datePeriodBasePath}`,
     });

--- a/src/common/utils/date-time/compare.ts
+++ b/src/common/utils/date-time/compare.ts
@@ -1,0 +1,6 @@
+import isBefore from 'date-fns/isBefore';
+
+// eslint-disable-next-line import/prefer-default-export
+export function isDateBefore(dateA: Date, dateB: Date): boolean {
+  return isBefore(dateA, dateB);
+}

--- a/src/common/utils/date-time/format.ts
+++ b/src/common/utils/date-time/format.ts
@@ -9,6 +9,9 @@ export const datetimeFormFormat = `${dateFormFormat} HH:mm`;
 export const formatDate = (date: string): string =>
   format(new Date(date), dateFormFormat);
 
+export const parseFormDate = (date: string): Date =>
+  parse(date, dateFormFormat, new Date());
+
 export const formatDateRange = ({
   startDate,
   endDate,
@@ -32,7 +35,7 @@ export const formatDateRange = ({
 };
 
 export const transformDateToApiFormat = (formDate: string): string =>
-  format(parse(formDate, dateFormFormat, new Date()), dateApiFormat);
+  format(parseFormDate(formDate), dateApiFormat);
 
 export const dropMilliseconds = (time: string): string => time.slice(0, -3);
 

--- a/src/components/datepicker/Datepicker.tsx
+++ b/src/components/datepicker/Datepicker.tsx
@@ -32,6 +32,11 @@ const datetimeRegex = /^\d{2}\.\d{2}\.\d{4} \d{2}:\d{2}$/;
 
 type TimeObject = { hours: number; minutes: number };
 
+export type DatepickerError = {
+  type: string;
+  text?: string;
+};
+
 function getTimeObjects(interval = 15): TimeObject[] {
   const times: TimeObject[] = [];
 
@@ -50,7 +55,7 @@ export type DatepickerProps = {
   disabled?: boolean;
   helperText?: string;
   id: string;
-  invalidText?: string;
+  error?: DatepickerError;
   labelText?: string;
   onBlur?: () => void;
   onChange: (value?: Date | null) => void;
@@ -60,6 +65,9 @@ export type DatepickerProps = {
   hideLabel?: boolean;
   required?: boolean;
   registerFn: Function;
+  customValidations?: {
+    [key: string]: (date: string | null) => boolean | string;
+  };
 };
 
 const Datepicker: React.FC<DatepickerProps> = ({
@@ -68,7 +76,7 @@ const Datepicker: React.FC<DatepickerProps> = ({
   value,
   id,
   helperText,
-  invalidText,
+  error,
   labelText,
   onChange,
   onBlur,
@@ -77,6 +85,7 @@ const Datepicker: React.FC<DatepickerProps> = ({
   hideLabel,
   required,
   registerFn,
+  customValidations,
 }) => {
   const [times] = useState(() =>
     getTimeObjects(minuteInterval || minuteInterval)
@@ -350,8 +359,8 @@ const Datepicker: React.FC<DatepickerProps> = ({
         <InputWrapper
           className={className}
           id={id}
-          helperText={invalidText || helperText}
-          invalid={!!invalidText}
+          helperText={error?.text ?? helperText}
+          invalid={!!error}
           labelText={labelText}
           hideLabel={hideLabel}
           hasIcon
@@ -360,10 +369,13 @@ const Datepicker: React.FC<DatepickerProps> = ({
             name={id}
             id={id}
             ref={(ref): void => {
-              registerFn(ref, { required });
+              registerFn(ref, {
+                required,
+                ...(customValidations ? { validate: customValidations } : {}),
+              });
             }}
             className={
-              invalidText
+              error
                 ? 'hds-text-input__input datepickerInput invalid'
                 : 'hds-text-input__input datepickerInput'
             }

--- a/src/opening-period/description/OpeningPeriodDescription.tsx
+++ b/src/opening-period/description/OpeningPeriodDescription.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FieldErrors } from 'react-hook-form/dist/types/errors.d';
 import { TextArea, TextInput } from 'hds-react';
 import './OpeningPeriodDescription.scss';
+import { TextFieldConfig } from '../../common/lib/types';
 
 type TFieldValues = {
   openingPeriodTitle: string;
@@ -10,12 +11,16 @@ type TFieldValues = {
 export default function OpeningPeriodDescription({
   register,
   errors,
+  nameFieldConfig,
 }: {
   register: Function;
   errors: FieldErrors<TFieldValues>;
+  nameFieldConfig: TextFieldConfig;
 }): JSX.Element {
   const hasError =
     errors.openingPeriodTitle && errors.openingPeriodTitle.type === 'required';
+
+  const titleMaxLength: number | undefined = nameFieldConfig.max_length;
 
   return (
     <>
@@ -31,11 +36,15 @@ export default function OpeningPeriodDescription({
           data-test="openingPeriodTitle"
           id="openingPeriodTitle"
           aria-invalid={errors.openingPeriodTitle ? 'true' : 'false'}
-          ref={register({ required: true, maxLength: 100 })}
+          ref={register({
+            required: true,
+            maxLength: titleMaxLength,
+          })}
           helperText={
             hasError ? 'Aukiolojakson otsikko on pakollinen' : undefined
           }
           invalid={hasError}
+          {...(titleMaxLength ? { maxLength: titleMaxLength } : {})}
         />
       </div>
       <div className="form-control">

--- a/src/opening-period/form/OpeningPeriodForm.scss
+++ b/src/opening-period/form/OpeningPeriodForm.scss
@@ -58,15 +58,15 @@
 
 .opening-period-time-period {
   display: flex;
-  align-items: center;
 }
 
 .dash-between-begin-and-end-date {
   font-family: HelsinkiGrotesk-Bold, Arial, sans-serif;
-  margin: 2rem 10px 0;
+  margin: calc(3rem - 2px) 10px 0;
 }
 
-.opening-period-notification-text {
+.opening-period-notification-text,
+.opening-period-error-text {
   display: flex;
 
   > * + * {

--- a/src/opening-period/form/OpeningPeriodForm.test.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { getElementOrThrow } from '../../../test/test-utils';
 import {
   DatePeriod,
@@ -176,7 +176,36 @@ const renderOpeningPeriodForm = (props: OpeningPeriodFormProps): Element => {
 };
 
 describe(`<OpeningPeriodForm />`, () => {
-  describe(`TimeSpanGroups`, () => {
+  describe('Validations', () => {
+    it('Should show required indicator when title is not set', async () => {
+      let container: Element;
+
+      await act(async () => {
+        container = renderOpeningPeriodForm(
+          defaultProps as OpeningPeriodFormProps
+        );
+      });
+
+      // try submit form without any input data:
+      await act(async () => {
+        // Try submit form
+        const submitFormButton = getElementOrThrow(
+          container,
+          '[data-test="publish-opening-period-button"]'
+        );
+        fireEvent.submit(submitFormButton);
+      });
+
+      await act(async () => {
+        const requiredIndicator = await screen.findByText(
+          'Aukiolojakson otsikko on pakollinen'
+        );
+        expect(requiredIndicator).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('TimeSpanGroups', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });

--- a/src/opening-period/form/OpeningPeriodForm.test.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.test.tsx
@@ -18,6 +18,9 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const testDatePeriodOptions: UiDatePeriodConfig = {
+  name: {
+    max_length: 255,
+  },
   resourceState: {
     options: [],
   },

--- a/src/opening-period/form/OpeningPeriodForm.test.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.test.tsx
@@ -203,6 +203,37 @@ describe(`<OpeningPeriodForm />`, () => {
         expect(requiredIndicator).toBeInTheDocument();
       });
     });
+
+    it('Should show required indicator when title is not set', async () => {
+      let container: Element;
+
+      await act(async () => {
+        container = renderOpeningPeriodForm({
+          ...defaultProps,
+          datePeriod: {
+            ...baseTestDatePeriod,
+            start_date: '2021-2-2',
+            end_date: '2021-2-1',
+          },
+        } as OpeningPeriodFormProps);
+      });
+
+      // try submit form with invalid date range:
+      await act(async () => {
+        const submitFormButton = getElementOrThrow(
+          container,
+          '[data-test="publish-opening-period-button"]'
+        );
+        fireEvent.submit(submitFormButton);
+      });
+
+      await act(async () => {
+        const requiredIndicator = await screen.findByText(
+          'Aukiolojakson alkupäivämäärä ei voi olla loppupäivämäärän jälkeen.'
+        );
+        expect(requiredIndicator).toBeInTheDocument();
+      });
+    });
   });
 
   describe('TimeSpanGroups', () => {

--- a/src/opening-period/form/OpeningPeriodForm.test.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.test.tsx
@@ -228,10 +228,10 @@ describe(`<OpeningPeriodForm />`, () => {
       });
 
       await act(async () => {
-        const requiredIndicator = await screen.findByText(
+        const invalidDateRangeIndicator = await screen.findByText(
           'Aukiolojakson alkupäivämäärä ei voi olla loppupäivämäärän jälkeen.'
         );
-        expect(requiredIndicator).toBeInTheDocument();
+        expect(invalidDateRangeIndicator).toBeInTheDocument();
       });
     });
   });

--- a/src/opening-period/form/OpeningPeriodForm.test.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.test.tsx
@@ -204,7 +204,7 @@ describe(`<OpeningPeriodForm />`, () => {
       });
     });
 
-    it('Should show required indicator when title is not set', async () => {
+    it('Should show error text when date-range is invalid', async () => {
       let container: Element;
 
       await act(async () => {

--- a/src/opening-period/form/OpeningPeriodForm.test.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.test.tsx
@@ -229,7 +229,7 @@ describe(`<OpeningPeriodForm />`, () => {
 
       await act(async () => {
         const invalidDateRangeIndicator = await screen.findByText(
-          'Aukiolojakson alkupäivämäärä ei voi olla loppupäivämäärän jälkeen.'
+          'Aukiolojakson loppupäivämäärä ei voi olla ennen alkupäivämäärää.'
         );
         expect(invalidDateRangeIndicator).toBeInTheDocument();
       });

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -9,7 +9,11 @@ import {
   TimeSpanFormFormat,
   TimeSpanGroupFormFormat,
 } from '../../common/lib/types';
-import { transformDateToApiFormat } from '../../common/utils/date-time/format';
+import { isDateBefore } from '../../common/utils/date-time/compare';
+import {
+  parseFormDate,
+  transformDateToApiFormat,
+} from '../../common/utils/date-time/format';
 import Datepicker from '../../components/datepicker/Datepicker';
 import {
   PrimaryButton,
@@ -52,6 +56,20 @@ export type OpeningPeriodFormProps = {
   submitFn: (datePeriod: DatePeriod) => Promise<DatePeriod>;
   successTextAndLabel: NotificationTexts;
   errorTextAndLabel: NotificationTexts;
+};
+
+const validateStartInputWithEndDate = (end: Date | null) => (
+  start: string | null
+): boolean | string => {
+  if (!start || !end) {
+    return true;
+  }
+
+  if (!isDateBefore(parseFormDate(start), end)) {
+    return 'Aukiolojakson alkupäivämäärä ei voi olla loppupäivämäärän jälkeen.';
+  }
+
+  return true;
 };
 
 export default function OpeningPeriodForm({
@@ -188,7 +206,11 @@ export default function OpeningPeriodForm({
               labelText="Alkaa"
               onChange={(value): void => setPeriodBeginDate(value || null)}
               value={periodBeginDate}
+              error={errors.openingPeriodBeginDate}
               registerFn={register}
+              customValidations={{
+                dateRange: validateStartInputWithEndDate(periodEndDate),
+              }}
             />
             <p className="dash-between-begin-and-end-date">—</p>
             <Datepicker
@@ -200,6 +222,16 @@ export default function OpeningPeriodForm({
               registerFn={register}
             />
           </section>
+          {errors.openingPeriodBeginDate?.type === 'dateRange' && (
+            <div className="hds-text-input__helper-text opening-period-error-text">
+              <span className="text-danger">
+                <IconAlertCircle />
+              </span>
+              <span className="text-danger">
+                {errors.openingPeriodBeginDate.message}
+              </span>
+            </div>
+          )}
         </div>
       </section>
       {timeSpanGroupFields.map(

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -65,6 +65,7 @@ export default function OpeningPeriodForm({
 }: OpeningPeriodFormProps): JSX.Element {
   const language = Language.FI;
   const {
+    name: nameFieldConfig,
     resourceState: resourceStateConfig,
     timeSpanGroup: { rule: ruleConfig },
   } = datePeriodConfig;
@@ -171,7 +172,11 @@ export default function OpeningPeriodForm({
       className="opening-period-form"
       onSubmit={handleSubmit(onSubmit)}>
       <section className="form-section">
-        <OpeningPeriodDescription register={register} errors={errors} />
+        <OpeningPeriodDescription
+          register={register}
+          errors={errors}
+          nameFieldConfig={nameFieldConfig}
+        />
       </section>
       <section className="form-section">
         <h3 className="opening-period-section-title">Ajanjakso</h3>

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -58,15 +58,15 @@ export type OpeningPeriodFormProps = {
   errorTextAndLabel: NotificationTexts;
 };
 
-const validateStartInputWithEndDate = (end: Date | null) => (
-  start: string | null
+const validateEndInputWithStartDate = (start: Date | null) => (
+  end: string | null
 ): boolean | string => {
   if (!start || !end) {
     return true;
   }
 
-  if (!isDateBefore(parseFormDate(start), end)) {
-    return 'Aukiolojakson alkupäivämäärä ei voi olla loppupäivämäärän jälkeen.';
+  if (isDateBefore(parseFormDate(end), start)) {
+    return 'Aukiolojakson loppupäivämäärä ei voi olla ennen alkupäivämäärää.';
   }
 
   return true;
@@ -208,9 +208,6 @@ export default function OpeningPeriodForm({
               value={periodBeginDate}
               error={errors.openingPeriodBeginDate}
               registerFn={register}
-              customValidations={{
-                dateRange: validateStartInputWithEndDate(periodEndDate),
-              }}
             />
             <p className="dash-between-begin-and-end-date">—</p>
             <Datepicker
@@ -220,15 +217,18 @@ export default function OpeningPeriodForm({
               onChange={(value): void => setPeriodEndDate(value || null)}
               value={periodEndDate}
               registerFn={register}
+              customValidations={{
+                dateRange: validateEndInputWithStartDate(periodBeginDate),
+              }}
             />
           </section>
-          {errors.openingPeriodBeginDate?.type === 'dateRange' && (
+          {errors.openingPeriodEndDate?.type === 'dateRange' && (
             <div className="hds-text-input__helper-text opening-period-error-text">
               <span className="text-danger">
                 <IconAlertCircle />
               </span>
               <span className="text-danger">
-                {errors.openingPeriodBeginDate.message}
+                {errors.openingPeriodEndDate?.message}
               </span>
             </div>
           )}

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
@@ -216,7 +216,7 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
       .mockImplementation(() => Promise.resolve(testResource));
 
     jest
-      .spyOn(api, 'getDatePeriodFormOptions')
+      .spyOn(api, 'getDatePeriodFormConfig')
       .mockImplementation(() => Promise.resolve(testDatePeriodConfig));
 
     jest
@@ -245,7 +245,7 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
   });
 
   it('should show loading indicator while loading date period form options', async () => {
-    jest.spyOn(api, 'getDatePeriodFormOptions').mockImplementation(() => {
+    jest.spyOn(api, 'getDatePeriodFormConfig').mockImplementation(() => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       return new Promise(() => {});
     });
@@ -293,7 +293,7 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
       .mockImplementationOnce((e) => e);
 
     jest
-      .spyOn(api, 'getDatePeriodFormOptions')
+      .spyOn(api, 'getDatePeriodFormConfig')
       .mockImplementation(() => Promise.reject(error));
 
     render(<CreateNewOpeningPeriodPage resourceId="tprek:8100" />);

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
@@ -203,7 +203,6 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
       is_removed: false,
       name: { fi: '', sv: '', en: '' },
       description: { fi: '', sv: '', en: '' },
-      start_date: '',
       end_date: '2020-11-21',
       resource_state: ResourceState.OPEN,
       override: false,

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
@@ -541,36 +541,4 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
       ).toThrow();
     });
   });
-
-  it('Should show required indicator when title is not set', async () => {
-    let container: Element;
-
-    await act(async () => {
-      container = render(<CreateNewOpeningPeriodPage resourceId="tprek:8100" />)
-        .container;
-
-      if (!container) {
-        throw new Error(
-          'Something went wrong in rendering of CreateNewOpeningPeriodPage'
-        );
-      }
-    });
-
-    // try submit form without any input data:
-    await act(async () => {
-      // Try submit form
-      const submitFormButton = getElementOrThrow(
-        container,
-        '[data-test="publish-opening-period-button"]'
-      );
-      fireEvent.submit(submitFormButton);
-    });
-
-    await act(async () => {
-      const requiredIndicator = await screen.findByText(
-        'Aukiolojakson otsikko on pakollinen'
-      );
-      expect(requiredIndicator).toBeInTheDocument();
-    });
-  });
 });

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.tsx
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.tsx
@@ -36,7 +36,7 @@ export default function CreateNewOpeningPeriodPage({
       try {
         const [apiResource, uiDatePeriodOptions] = await Promise.all([
           api.getResource(resourceId),
-          api.getDatePeriodFormOptions(),
+          api.getDatePeriodFormConfig(),
         ]);
         setResource(apiResource);
         setDatePeriodConfig(uiDatePeriodOptions);

--- a/src/opening-period/page/EditOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.test.tsx
@@ -198,7 +198,7 @@ describe(`<EditNewOpeningPeriodPage />`, () => {
       .mockImplementation(() => Promise.resolve(testResource));
 
     jest
-      .spyOn(api, 'getDatePeriodFormOptions')
+      .spyOn(api, 'getDatePeriodFormConfig')
       .mockImplementation(() => Promise.resolve(testDatePeriodOptions));
 
     jest

--- a/src/opening-period/page/EditOpeningPeriodPage.tsx
+++ b/src/opening-period/page/EditOpeningPeriodPage.tsx
@@ -45,7 +45,7 @@ export default function EditOpeningPeriodPage({
         ] = await Promise.all([
           api.getResource(resourceId),
           api.getDatePeriod(id),
-          api.getDatePeriodFormOptions(),
+          api.getDatePeriodFormConfig(),
         ]);
         setResource(apiResource);
         setDatePeriod(apiDatePeriod);

--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -6,7 +6,7 @@ import Weekdays from './Weekdays';
 import './TimeSpan.scss';
 import TimeInput from './TimeInput';
 import {
-  UiFieldConfig,
+  UiOptionsFieldConfig,
   TimeSpanFormFormat,
   InputOption,
 } from '../../common/lib/types';
@@ -28,7 +28,7 @@ export default function TimeSpan({
   remove: Function;
   register: Function;
   control: Control;
-  resourceStateConfig: UiFieldConfig;
+  resourceStateConfig: UiOptionsFieldConfig;
 }): JSX.Element {
   const timeSpanNamePrefix = `${namePrefix}[${index}]`;
   const { options: resourceStateOptions } = resourceStateConfig;

--- a/src/opening-period/time-span/TimeSpans.tsx
+++ b/src/opening-period/time-span/TimeSpans.tsx
@@ -2,7 +2,10 @@ import React, { useEffect } from 'react';
 import { ArrayField, Control, useFieldArray } from 'react-hook-form';
 import { IconClockPlus } from 'hds-react';
 import { SecondaryButton } from '../../components/button/Button';
-import { TimeSpanFormFormat, UiFieldConfig } from '../../common/lib/types';
+import {
+  TimeSpanFormFormat,
+  UiOptionsFieldConfig,
+} from '../../common/lib/types';
 import TimeSpan from './TimeSpan';
 
 export default function TimeSpans({
@@ -17,7 +20,7 @@ export default function TimeSpans({
   groupId?: string;
   namePrefix: string;
   control: Control;
-  resourceStateConfig: UiFieldConfig;
+  resourceStateConfig: UiOptionsFieldConfig;
   register: Function;
 }): JSX.Element {
   const initTimeSpan: Partial<TimeSpanFormFormat> = { group: groupId ?? '' };

--- a/src/resource/page/ResourcePage.test.tsx
+++ b/src/resource/page/ResourcePage.test.tsx
@@ -115,7 +115,7 @@ describe(`<ResourcePage />`, () => {
       .mockImplementation(() => Promise.resolve([testDatePeriod]));
 
     jest
-      .spyOn(api, 'getDatePeriodFormOptions')
+      .spyOn(api, 'getDatePeriodFormConfig')
       .mockImplementation(() => Promise.resolve(testDatePeriodOptions));
 
     jest

--- a/src/resource/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/resource/resource-opening-hours/ResourceOpeningHours.tsx
@@ -133,7 +133,7 @@ export default function ResourceOpeningHours({
     try {
       const [apiDatePeriods, uiDatePeriodOptions] = await Promise.all([
         api.getDatePeriods(id),
-        api.getDatePeriodFormOptions(),
+        api.getDatePeriodFormConfig(),
       ]);
       const datePeriodLists = partitionByOverride(apiDatePeriods);
       setDividedDatePeriods(datePeriodLists);

--- a/src/resource/resource-opening-hours/opening-period/PeriodOpeningHours.tsx
+++ b/src/resource/resource-opening-hours/opening-period/PeriodOpeningHours.tsx
@@ -4,7 +4,7 @@ import {
   Language,
   ResourceState,
   UiDatePeriodConfig,
-  UiFieldConfig,
+  UiOptionsFieldConfig,
 } from '../../../common/lib/types';
 import {
   createWeekdaysStringFromIndices,
@@ -14,7 +14,7 @@ import './PeriodOpeningHours.scss';
 
 function findResourceStateLabelByValue(
   value: ResourceState | undefined,
-  resourceState: UiFieldConfig
+  resourceState: UiOptionsFieldConfig
 ): string | undefined {
   return resourceState.options.find(
     (resourceStateOption) => resourceStateOption.value === value

--- a/test/fixtures/api-options.ts
+++ b/test/fixtures/api-options.ts
@@ -2,6 +2,9 @@ import { UiDatePeriodConfig as DatePeriodConfig } from '../../src/common/lib/typ
 
 // eslint-disable-next-line import/prefer-default-export
 export const datePeriodOptions: DatePeriodConfig = {
+  name: {
+    max_length: 255,
+  },
   resourceState: {
     options: [
       {


### PR DESCRIPTION
- Add max-length restriction to date-period name field (use api value for it)
- Validate date-range on submit

<img width="650" alt="Näyttökuva 2021-2-3 kello 10 02 02" src="https://user-images.githubusercontent.com/1610860/106728540-3b4a3f00-6615-11eb-9a1e-ba4738c614e0.png">
