### PR TITLE
Fix useArrayField types

### DIFF
--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -11,7 +11,6 @@ import {
   DatePeriod,
   UiDatePeriodConfig,
   Language,
-  TimeSpanFormFormat,
   TimeSpanGroupFormFormat,
   UiFieldConfig,
   UiFormRuleConfig,
@@ -174,7 +173,7 @@ export default function OpeningPeriodForm({
     fields: timeSpanGroupFields,
     append: appendTimeSpanGroup,
     remove: removeTimeSpanGroup,
-  } = useFieldArray({
+  } = useFieldArray<TimeSpanGroupFormFormat, 'timeSpanGroupUiId'>({
     control,
     keyName: 'timeSpanGroupUiId',
     name: timeSpanGroupFieldName,
@@ -289,7 +288,7 @@ export default function OpeningPeriodForm({
         {timeSpanGroupFields.map(
           (
             timeSpanGroup: Partial<
-              ArrayField<Record<string, TimeSpanFormFormat>>
+              ArrayField<TimeSpanGroupFormFormat, 'timeSpanGroupUiId'>
             >,
             index: number
           ) => (
@@ -311,13 +310,13 @@ export default function OpeningPeriodForm({
               <input
                 type="hidden"
                 name={`${timeSpanGroupFieldName}[${index}].id`}
-                defaultValue={`${timeSpanGroup.id || ''}`}
+                defaultValue={timeSpanGroup.id}
                 ref={register()}
               />
               <input
                 type="hidden"
                 name={`${timeSpanGroupFieldName}[${index}].period`}
-                defaultValue={`${timeSpanGroup.period || ''}`}
+                defaultValue={timeSpanGroup.period}
                 ref={register()}
               />
               <TimeSpans

--- a/src/opening-period/rule/Rule.tsx
+++ b/src/opening-period/rule/Rule.tsx
@@ -99,7 +99,7 @@ export default function Rule({
   errors,
 }: {
   namePrefix: string;
-  rule: Partial<ArrayField<Record<string, GroupRuleFormFormat>>>;
+  rule: Partial<ArrayField<GroupRuleFormFormat, 'ruleUiId'>>;
   remove: Function;
   index: number;
   groupIndex: number;
@@ -129,16 +129,16 @@ export default function Rule({
   const ruleErrors = errors && errors[index];
 
   const selectedSubject = subjectOptions.find(
-    ({ value }: InputOption) => value === `${subject}`
+    ({ value }: InputOption) => value === subject
   );
   const [subjectLabel, setSubjectLabel] = useState<string>(
     selectedSubject?.label ?? ''
   );
 
-  const currentFrequency = {
+  const currentFrequency: Frequency = {
     frequency_modifier: frequencyModifier,
     frequency_ordinal: frequencyOrdinal,
-  } as Frequency;
+  };
 
   const knownFrequencyValues: FrequencyOption[] = [
     ...hardCodedFrequencyOptions,
@@ -231,7 +231,7 @@ export default function Rule({
       <input
         type="hidden"
         name={`${ruleNamePrefix}.group`}
-        defaultValue={`${group || ''}`}
+        defaultValue={group}
         ref={register()}
       />
       <div className="form-control-header">
@@ -248,7 +248,7 @@ export default function Rule({
           key={`rule-context-${groupIndex}-${index}`}
           name={`${ruleNamePrefix}.context`}
           control={control}
-          defaultValue={`${context || ''}`}
+          defaultValue={context || ''}
           rules={{
             required: {
               value: contextRequired,
@@ -293,7 +293,7 @@ export default function Rule({
           key={`rule-subject-${groupIndex}-${index}`}
           name={`${ruleNamePrefix}.subject`}
           control={control}
-          defaultValue={`${subject || ''}`}
+          defaultValue={subject || ''}
           rules={{
             required: {
               value: subjectRequired,
@@ -327,7 +327,7 @@ export default function Rule({
             key={`rule-start-${groupIndex}-${index}`}
             name={`${ruleNamePrefix}.start`}
             control={control}
-            defaultValue={`${startAt || ''}`}
+            defaultValue={startAt || ''}
             rules={{
               required: {
                 value: startRequired,

--- a/src/opening-period/rule/Rules.tsx
+++ b/src/opening-period/rule/Rules.tsx
@@ -32,7 +32,10 @@ export default function Rules({
 }): JSX.Element {
   const { control } = useFormContext();
   const ruleNamePrefix = `${namePrefix}[${groupIndex}].rules`;
-  const { fields, remove, append } = useFieldArray({
+  const { fields, remove, append } = useFieldArray<
+    GroupRuleFormFormat,
+    'ruleUiId'
+  >({
     control,
     name: ruleNamePrefix,
     keyName: 'ruleUiId',
@@ -49,7 +52,7 @@ export default function Rules({
           data-test="rule-list">
           {fields.map(
             (
-              rule: Partial<ArrayField<Record<string, GroupRuleFormFormat>>>,
+              rule: Partial<ArrayField<GroupRuleFormFormat, 'ruleUiId'>>,
               index: number
             ) => (
               <li

--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -28,7 +28,7 @@ export default function TimeSpan({
   resourceStateConfig,
   errors,
 }: {
-  item: Partial<ArrayField<Record<string, TimeSpanFormFormat>>>;
+  item: Partial<ArrayField<TimeSpanFormFormat, 'timeSpanUiId'>>;
   namePrefix: string;
   index: number;
   groupIndex: number;
@@ -57,7 +57,7 @@ export default function TimeSpan({
       <input
         type="hidden"
         name={`${timeSpanNamePrefix}.group`}
-        defaultValue={`${item.group || ''}`}
+        defaultValue={item.group}
         ref={register()}
       />
       <div className="time-span-first-header-row form-control">
@@ -95,7 +95,7 @@ export default function TimeSpan({
                     ),
                 })
               }
-              defaultValue={`${item.startTime}`}
+              defaultValue={item.startTime || ''}
               error={timeSpanErrors?.startTime?.message}
               id={`time-span-${groupIndex}-${index}-start-time`}
               name={`${timeSpanNamePrefix}.startTime`}
@@ -117,7 +117,7 @@ export default function TimeSpan({
                   ),
               })
             }
-            defaultValue={`${item.endTime}`}
+            defaultValue={item.endTime || ''}
             id={`time-span-end-time-${groupIndex}-${index}`}
             name={`${timeSpanNamePrefix}.endTime`}
             placeholder="--.--"
@@ -133,7 +133,7 @@ export default function TimeSpan({
           <Controller
             control={control}
             name={`${timeSpanNamePrefix}.resourceState`}
-            defaultValue={`${item.resourceState || ResourceState.OPEN}`}
+            defaultValue={item.resourceState || ResourceState.OPEN}
             render={({ onChange, value }): JSX.Element => (
               <Select
                 id={`time-span-state-id-${groupIndex}-${index}`}
@@ -159,7 +159,7 @@ export default function TimeSpan({
             id={`time-span-description-${groupIndex}-${index}`}
             name={`${timeSpanNamePrefix}.description`}
             className="time-span-description"
-            defaultValue={`${item.description || ''}`}
+            defaultValue={item.description || ''}
             label="Kuvaus"
             placeholder="Valinnainen lyhyt kuvaus esim. naisten vuoro"
           />

--- a/src/opening-period/time-span/TimeSpans.tsx
+++ b/src/opening-period/time-span/TimeSpans.tsx
@@ -33,7 +33,10 @@ export default function TimeSpans({
   const { control } = useFormContext();
   const initTimeSpan: Partial<TimeSpanFormFormat> = { group: groupId ?? '' };
   const timeSpanNamePrefix = `${namePrefix}[${groupIndex}].timeSpans`;
-  const { fields, remove, append } = useFieldArray({
+  const { fields, remove, append } = useFieldArray<
+    TimeSpanFormFormat,
+    'timeSpanUiId'
+  >({
     control,
     keyName: 'timeSpanUiId',
     name: timeSpanNamePrefix,
@@ -54,7 +57,7 @@ export default function TimeSpans({
           data-test={`time-span-list-${groupIndex}`}>
           {fields.map(
             (
-              item: Partial<ArrayField<Record<string, TimeSpanFormFormat>>>,
+              item: Partial<ArrayField<TimeSpanFormFormat, 'timeSpanUiId'>>,
               index: number
             ) => (
               <li

--- a/src/opening-period/time-span/Weekdays.tsx
+++ b/src/opening-period/time-span/Weekdays.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import './Weekdays.scss';
 import { ArrayField } from 'react-hook-form';
-import { TimeSpanFormFormat, FormWeekdays } from '../../common/lib/types';
+import { TimeSpanFormFormat } from '../../common/lib/types';
 
 const DayCheckbox = ({
   register,

--- a/src/opening-period/time-span/Weekdays.tsx
+++ b/src/opening-period/time-span/Weekdays.tsx
@@ -46,16 +46,15 @@ export default function Weekdays({
   index: number;
   groupIndex: number;
   register: Function;
-  item: Partial<ArrayField<Record<string, TimeSpanFormFormat>>>;
+  item: Partial<ArrayField<TimeSpanFormFormat, 'timeSpanUiId'>>;
 }): JSX.Element {
-  const asWeekdaysValue = (item.weekdays as unknown) as FormWeekdays;
   const weekdaysNamePrefix = `${namePrefix}.weekdays`;
 
   return (
     <fieldset>
       <legend>Päivät *</legend>
       <DayCheckbox
-        weekdays={asWeekdaysValue}
+        weekdays={item.weekdays}
         register={register}
         dataTest={`weekdays-monday-${groupIndex}-${index}`}
         namePrefix={weekdaysNamePrefix}
@@ -63,7 +62,7 @@ export default function Weekdays({
         Ma
       </DayCheckbox>
       <DayCheckbox
-        weekdays={asWeekdaysValue}
+        weekdays={item.weekdays}
         register={register}
         dataTest={`weekdays-tuesday-${groupIndex}-${index}`}
         namePrefix={weekdaysNamePrefix}
@@ -71,7 +70,7 @@ export default function Weekdays({
         Ti
       </DayCheckbox>
       <DayCheckbox
-        weekdays={asWeekdaysValue}
+        weekdays={item.weekdays}
         register={register}
         dataTest={`weekdays-wednesday-${groupIndex}-${index}`}
         namePrefix={weekdaysNamePrefix}
@@ -79,7 +78,7 @@ export default function Weekdays({
         Ke
       </DayCheckbox>
       <DayCheckbox
-        weekdays={asWeekdaysValue}
+        weekdays={item.weekdays}
         register={register}
         dataTest={`weekdays-thursday-${groupIndex}-${index}`}
         namePrefix={weekdaysNamePrefix}
@@ -87,7 +86,7 @@ export default function Weekdays({
         To
       </DayCheckbox>
       <DayCheckbox
-        weekdays={asWeekdaysValue}
+        weekdays={item.weekdays}
         register={register}
         dataTest={`weekdays-friday-${groupIndex}-${index}`}
         namePrefix={weekdaysNamePrefix}
@@ -95,7 +94,7 @@ export default function Weekdays({
         Pe
       </DayCheckbox>
       <DayCheckbox
-        weekdays={asWeekdaysValue}
+        weekdays={item.weekdays}
         register={register}
         dataTest={`weekdays-saturday-${groupIndex}-${index}`}
         namePrefix={weekdaysNamePrefix}
@@ -103,7 +102,7 @@ export default function Weekdays({
         La
       </DayCheckbox>
       <DayCheckbox
-        weekdays={asWeekdaysValue}
+        weekdays={item.weekdays}
         register={register}
         dataTest={`weekdays-sunday-${groupIndex}-${index}`}
         namePrefix={weekdaysNamePrefix}


### PR DESCRIPTION
Fix useArrayField types:
1. Initialize arrayField type in the useArrayField call by providing the value type and the key for ui-id field (uses 'id' by default):

      React-hook-form type implementation for useArrayFields is like this: 
      ```TFieldArrayValues extends Record<string, any> = Record<string, any>, TKeyName extends string = "id"```
      
      ...so we can provide:
      `useArrayField<TimeSpanFormFormat, 'timeSpanUiId'>` 
2. Add types to fields map callback using ArrayField and providing the previous type as value type. 
Needs to be partial because the fields are typed as partial in the react-hook-form's type implementation:
      ```ts
        fields.map(timeSpanGroup: Partial<ArrayField<TimeSpanFormFormat, 'timeSpanUiId'>> => )
      ```