### PR TITLE
Set inline-notification z-index with a component prop

### DIFF
--- a/src/opening-period/form/OpeningPeriodForm.scss
+++ b/src/opening-period/form/OpeningPeriodForm.scss
@@ -72,10 +72,6 @@
   --textarea-height: 6rem;
 }
 
-.opening-period-form-notification {
-  z-index: 0;
-}
-
 .opening-period-time-period {
   display: flex;
 }

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -346,7 +346,7 @@ export default function OpeningPeriodForm({
             className="form-section time-span-group">
             <Notification
               label="Aukiolojaksolle on valittu aukiolotila"
-              className="opening-period-form-notification">
+              style={{ zIndex: 0 }}>
               Kun aukiolojaksolle on valittu aukiolotila niin se poistaa tämän
               jakson kaikki muut mahdolliset aukiolot.
             </Notification>


### PR DESCRIPTION
When overwriting **HDS** styles with CSS classes, the classes will have lower specificity in production build than in dev build. 
Fixed the issue by giving the overwriting style declaration in the component style attribute. 
The problem was that the inline notification overlaps the select's options list.

<img width="975" alt="Näyttökuva 2021-2-23 kello 10 13 34" src="https://user-images.githubusercontent.com/1610860/108816974-d2c10300-75bf-11eb-8eac-6a57f98717b0.png">
