### PR TITLE
Set dateperiod's start_date and end_date as null by default

### DIFF
--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -207,8 +207,8 @@ export type DatePeriod = {
   is_removed?: boolean;
   name: LanguageStrings;
   description: LanguageStrings;
-  start_date?: string;
-  end_date?: string;
+  start_date: string | null;
+  end_date: string | null;
   resource_state?: ResourceState;
   override: boolean;
   resource: number;

--- a/src/common/utils/date-time/format.test.ts
+++ b/src/common/utils/date-time/format.test.ts
@@ -12,19 +12,21 @@ describe('format', () => {
     });
 
     it('should return formatted startDate when endDate is missing', () => {
-      expect(formatDateRange({ startDate: '2020-12-18' })).toEqual(
-        '18.12.2020 alkaen'
-      );
+      expect(
+        formatDateRange({ startDate: '2020-12-18', endDate: null })
+      ).toEqual('18.12.2020 alkaen');
     });
 
     it('should return formatted endDate when startDate is missing', () => {
-      expect(formatDateRange({ endDate: '2020-12-31' })).toEqual(
-        '31.12.2020 asti'
-      );
+      expect(
+        formatDateRange({ startDate: null, endDate: '2020-12-31' })
+      ).toEqual('31.12.2020 asti');
     });
 
     it('should return valid under further notice when both endDate and startDate are missing', () => {
-      expect(formatDateRange({})).toEqual('Voimassa toistaiseksi');
+      expect(formatDateRange({ startDate: null, endDate: null })).toEqual(
+        'Voimassa toistaiseksi'
+      );
     });
   });
 

--- a/src/common/utils/date-time/format.ts
+++ b/src/common/utils/date-time/format.ts
@@ -16,8 +16,8 @@ export const formatDateRange = ({
   startDate,
   endDate,
 }: {
-  startDate?: string;
-  endDate?: string;
+  startDate: string | null;
+  endDate: string | null;
 }): string => {
   if (!startDate && !endDate) {
     return 'Voimassa toistaiseksi';

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -43,8 +43,8 @@ import './OpeningPeriodForm.scss';
 interface OpeningPeriodFormData {
   openingPeriodTitle: LanguageStrings;
   openingPeriodOptionalDescription: LanguageStrings;
-  openingPeriodBeginDate: string | undefined;
-  openingPeriodEndDate: string | undefined;
+  openingPeriodBeginDate: string | null;
+  openingPeriodEndDate: string | null;
   openingPeriodResourceState: ResourceState | undefined;
   timeSpanGroups: TimeSpanGroupFormFormat[];
 }
@@ -162,8 +162,8 @@ export default function OpeningPeriodForm({
   const formValues: OpeningPeriodFormData = {
     openingPeriodTitle: datePeriod?.name || emptyLanguages,
     openingPeriodOptionalDescription: datePeriod?.description || emptyLanguages,
-    openingPeriodBeginDate: datePeriod?.start_date,
-    openingPeriodEndDate: datePeriod?.end_date,
+    openingPeriodBeginDate: datePeriod?.start_date ?? null,
+    openingPeriodEndDate: datePeriod?.end_date ?? null,
     openingPeriodResourceState: datePeriod?.resource_state,
     timeSpanGroups: [defaultTimeSpanGroup],
   };
@@ -217,10 +217,10 @@ export default function OpeningPeriodForm({
         description: data.openingPeriodOptionalDescription,
         start_date: data.openingPeriodBeginDate
           ? transformDateToApiFormat(data.openingPeriodBeginDate)
-          : undefined,
+          : null,
         end_date: data.openingPeriodEndDate
           ? transformDateToApiFormat(data.openingPeriodEndDate)
-          : undefined,
+          : null,
         resource_state: data.openingPeriodResourceState,
         override: forceException || datePeriod?.override || false,
         time_span_groups: isResourceStateSet(data?.openingPeriodResourceState)

--- a/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
+++ b/src/opening-period/page/CreateNewOpeningPeriodPage.test.tsx
@@ -203,6 +203,7 @@ describe(`<CreateNewOpeningPeriodPage />`, () => {
       is_removed: false,
       name: { fi: '', sv: '', en: '' },
       description: { fi: '', sv: '', en: '' },
+      start_date: null,
       end_date: '2020-11-21',
       resource_state: ResourceState.OPEN,
       override: false,

--- a/src/resource/resource-opening-hours/opening-period/OpeningPeriod.tsx
+++ b/src/resource/resource-opening-hours/opening-period/OpeningPeriod.tsx
@@ -39,9 +39,10 @@ export default function OpeningPeriod({
 }): JSX.Element {
   const datePeriodName = datePeriod.name[language];
   const formattedDateRange = formatDateRange({
-    startDate: datePeriod.start_date,
-    endDate: datePeriod.end_date,
+    startDate: datePeriod.start_date ?? null,
+    endDate: datePeriod.end_date ?? null,
   });
+
   const deleteModalTitle = 'Oletko varma että haluat poistaa aukiolojakson?';
   const DeleteModalText = (): JSX.Element => (
     <>


### PR DESCRIPTION
- Send empty start_date and end_date as null to API