### PR TITLE
Hauki 389 minor UI tweaks

### DIFF
--- a/src/components/icon-text/IconText.tsx
+++ b/src/components/icon-text/IconText.tsx
@@ -1,32 +1,56 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { IconAlertCircle } from 'hds-react';
 import './IconText.scss';
 
 type IconTextProps = {
   id: string;
   message: string;
+  className?: string;
 };
 
-export function ErrorText({ message, id }: IconTextProps): JSX.Element {
+const IconTextContainer = ({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}): JSX.Element => (
+  <div
+    className={`hds-text-input__helper-text custom-icon-text ${
+      className || ''
+    }`}>
+    {children}
+  </div>
+);
+
+export function ErrorText({
+  id,
+  message,
+  className,
+}: IconTextProps): JSX.Element {
   return (
-    <div className="hds-text-input__helper-text custom-icon-text">
+    <IconTextContainer className={className}>
       <span className="text-danger">
         <IconAlertCircle area-hidden="true" aria-labelledby={id} />
       </span>
       <span id={id} className="text-danger">
         {message}
       </span>
-    </div>
+    </IconTextContainer>
   );
 }
 
-export function NotificationText({ message, id }: IconTextProps): JSX.Element {
+export function NotificationText({
+  id,
+  message,
+  className,
+}: IconTextProps): JSX.Element {
   return (
-    <div className="hds-text-input__helper-text custom-icon-text">
+    <IconTextContainer className={className}>
       <span>
         <IconAlertCircle area-hidden="true" aria-labelledby={id} />
       </span>
       <span id={id}>{message}</span>
-    </div>
+    </IconTextContainer>
   );
 }

--- a/src/opening-period/description/OpeningPeriodDescription.tsx
+++ b/src/opening-period/description/OpeningPeriodDescription.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FieldErrors } from 'react-hook-form/dist/types/errors.d';
-import { Notification, TextArea, TextInput } from 'hds-react';
+import { TextArea, TextInput } from 'hds-react';
 import './OpeningPeriodDescription.scss';
 import {
   Language,

--- a/src/opening-period/description/OpeningPeriodDescription.tsx
+++ b/src/opening-period/description/OpeningPeriodDescription.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FieldErrors } from 'react-hook-form/dist/types/errors.d';
-import { TextArea, TextInput } from 'hds-react';
+import { Notification, TextArea, TextInput } from 'hds-react';
 import './OpeningPeriodDescription.scss';
 import {
   Language,
@@ -54,13 +54,17 @@ export default function OpeningPeriodDescription({
   nameFieldConfig: TextFieldConfig;
 }): JSX.Element {
   const hasError = !!errors.openingPeriodTitle;
-
   const titleMaxLength: number | undefined = nameFieldConfig.max_length;
 
   return (
     <>
       <h3 className="opening-period-section-title">Jakson kuvaus</h3>
       <div className="form-control">
+        <NotificationText
+          id="opening-period-title-info-text"
+          className="opening-period-notification-text"
+          message="Ole hyvä ja syötä otsikko ainakin yhdellä kielellä."
+        />
         <div className="opening-period-text-group">
           {Object.values(Language).map((languageKey: Language) => (
             <TextInput
@@ -97,14 +101,9 @@ export default function OpeningPeriodDescription({
             />
           ))}
         </div>
-        {hasError ? (
+        {hasError && (
           <ErrorText
             id="opening-period-title-error-text"
-            message="Aukiolojaksolla on oltava otsikko ainakin yhdellä kielellä."
-          />
-        ) : (
-          <NotificationText
-            id="opening-period-title-info-text"
             message="Aukiolojaksolla on oltava otsikko ainakin yhdellä kielellä."
           />
         )}

--- a/src/opening-period/form/OpeningPeriodForm.scss
+++ b/src/opening-period/form/OpeningPeriodForm.scss
@@ -85,11 +85,7 @@ $final-action-row-height: $spacing-layout-xl;
 }
 
 .opening-period-notification-text {
-  display: flex;
-
-  > * + * {
-    margin-left: $spacing-3-xs;
-  }
+  margin: $spacing-s 0;
 }
 
 .opening-period-resource-state {

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -6,7 +6,7 @@ import {
   useForm,
 } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
-import { IconAlertCircle, IconPlus, IconTrash, Notification } from 'hds-react';
+import { IconPlus, IconTrash, Notification } from 'hds-react';
 import {
   DatePeriod,
   Language,

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -28,7 +28,10 @@ import {
   SecondaryButton,
   SupplementaryButton,
 } from '../../components/button/Button';
-import { ErrorText } from '../../components/icon-text/IconText';
+import {
+  ErrorText,
+  NotificationText,
+} from '../../components/icon-text/IconText';
 import ResourceStateSelect from '../../components/resourse-state-select/ResourceStateSelect';
 import toast from '../../components/notification/Toast';
 import {
@@ -412,16 +415,12 @@ export default function OpeningPeriodForm({
             iconLeft={<IconPlus />}>
             Luo uusi aukioloryhmä tähän jaksoon
           </SupplementaryButton>
-          <p className="opening-period-notification-text">
-            <IconAlertCircle
-              area-hidden="true"
-              aria-labelledby="opening-period-group-info"
-            />
-            <span id="opening-period-group-info">
-              Lisää uusi ryhmä tähän aukiolojaksoon jos haluat lisätä
-              aukioloaikoja useammilla eri säännöillä
-            </span>
-          </p>
+          <NotificationText
+            id="opening-period-group-info"
+            className="opening-period-notification-text"
+            message="Lisää uusi ryhmä tähän aukiolojaksoon jos haluat lisätä
+              aukioloaikoja useammilla eri säännöillä"
+          />
         </div>
         <div className="opening-period-final-action-row-container">
           <MainContainer>

--- a/src/opening-period/time-span/TimeSpan.scss
+++ b/src/opening-period/time-span/TimeSpan.scss
@@ -23,12 +23,12 @@
   align-items: flex-end;
 }
 
-.checkbox-container {
+.time-span-fullday-checkbox-container {
   display: flex;
   align-items: center;
   height: var(--spacing-3-xl); // 56px, it is the height of the input
 }
 
 .time-span-end-time-input-wrapper {
-  margin-right: var(--spacing-layout-2-xl);
+  margin-right: var(--spacing-layout-l);
 }

--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -155,7 +155,7 @@ export default function TimeSpan({
             wrapperClassName="time-span-end-time-input-wrapper"
             disabled={fullDay}
           />
-          <div className="checkbox-container">
+          <div className="time-span-fullday-checkbox-container">
             <Checkbox
               id={`${timeSpanNamePrefix}.fullDay`}
               label="Koko päivä"


### PR DESCRIPTION
Show title requirements info before title-fields :
<img width="1388" alt="Näyttökuva 2021-2-24 kello 17 03 23" src="https://user-images.githubusercontent.com/1610860/109020161-62e77100-76c2-11eb-8482-b7b660d2df9a.png">

Move fullday-checkbox closer to time-range-inputs:
<img width="1311" alt="Näyttökuva 2021-2-24 kello 17 03 39" src="https://user-images.githubusercontent.com/1610860/109020155-624eda80-76c2-11eb-9d9b-a4a2488477e5.png">