### PR TITLE
Use correct date-format to parse initial API dates

### DIFF
--- a/src/common/utils/date-time/format.ts
+++ b/src/common/utils/date-time/format.ts
@@ -9,6 +9,9 @@ export const datetimeFormFormat = `${dateFormFormat} HH:mm`;
 export const formatDate = (date: string): string =>
   format(new Date(date), dateFormFormat);
 
+export const parseApiDate = (date: string): Date =>
+  parse(date, dateApiFormat, new Date());
+
 export const parseFormDate = (date: string): Date =>
   parse(date, dateFormFormat, new Date());
 

--- a/src/opening-period/form/OpeningPeriodForm.tsx
+++ b/src/opening-period/form/OpeningPeriodForm.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../common/lib/types';
 import { isDateBefore } from '../../common/utils/date-time/compare';
 import {
+  parseApiDate,
   parseFormDate,
   transformDateToApiFormat,
 } from '../../common/utils/date-time/format';
@@ -154,11 +155,11 @@ export default function OpeningPeriodForm({
   };
 
   const [periodBeginDate, setPeriodBeginDate] = useState<Date | null>(
-    datePeriod?.start_date ? new Date(datePeriod?.start_date) : null
+    datePeriod?.start_date ? parseApiDate(datePeriod?.start_date) : null
   );
 
   const [periodEndDate, setPeriodEndDate] = useState<Date | null>(
-    datePeriod?.end_date ? new Date(datePeriod?.end_date) : null
+    datePeriod?.end_date ? parseApiDate(datePeriod?.end_date) : null
   );
 
   const openingPeriodResourceStateKey = 'openingPeriodResourceState';


### PR DESCRIPTION
**Bug**: validation failed when the user tried to edit any field value of date-period with the same start-date and end-date.
**Cause**: initial start-date string is converted to date with JavaScript's Date class without date-format. The API will return the date in the 'yyyy-MM-dd' - format. The JavaScript Date will resolve the current time based on GMT threshold, so it will be 02:00. 
Date-fns will use 00:00 time when time is not defined in the date-format.
**Fix**: parse the API dates with date-fns parse function.