### PR TITLE
Fix icon-text alignment issue

### DIFF
--- a/src/components/icon-text/IconText.scss
+++ b/src/components/icon-text/IconText.scss
@@ -3,7 +3,7 @@
 .custom-icon-text {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
 
   > .custom-icon-text-icon {
     line-height: 1;


### PR DESCRIPTION
After hds-libraries update there is a small icon-text alignment issue:
<img width="1051" alt="Näyttökuva 2021-6-15 kello 15 05 52" src="https://user-images.githubusercontent.com/1610860/122050467-27e18880-cdec-11eb-902b-0bac71c4099a.png">
<img width="1189" alt="Näyttökuva 2021-6-15 kello 15 08 42" src="https://user-images.githubusercontent.com/1610860/122050458-26b05b80-cdec-11eb-97e4-55fd8426f16e.png">


Fixed: 
<img width="1258" alt="Näyttökuva 2021-6-15 kello 15 13 41" src="https://user-images.githubusercontent.com/1610860/122050619-4e9fbf00-cdec-11eb-9110-616548ad734a.png">
<img width="1151" alt="Näyttökuva 2021-6-15 kello 15 08 56" src="https://user-images.githubusercontent.com/1610860/122050470-287a1f00-cdec-11eb-85c5-b77ff30542e3.png">

