### PR TITLE
Adjust the most volatile e2e-tests' timeouts

### DIFF
--- a/cypress/integration/AddNewOpeningPeriod.spec.ts
+++ b/cypress/integration/AddNewOpeningPeriod.spec.ts
@@ -12,7 +12,7 @@ describe('User adds a new opening period', () => {
   it('User successfully adds a new opening period', () => {
     // Begin from resource page
     cy.get('[data-test=resource-opening-periods-list] ', {
-      timeout: 5000,
+      timeout: 10000,
     }).should('be.visible');
 
     // Go to add new opening period page by pressing the header button
@@ -20,7 +20,7 @@ describe('User adds a new opening period', () => {
 
     // Check that add new opening period form is visible in the new page
     cy.get('[data-test=add-new-opening-period-form]', {
-      timeout: 5000,
+      timeout: 10000,
     }).should('be.visible');
 
     // Start filling the form, first is opening period title in finnish
@@ -83,7 +83,7 @@ describe('User adds a new opening period', () => {
   it('User successfully adds a new opening period which is open through the period', () => {
     // Begin from resource page
     cy.get('[data-test=resource-opening-periods-list] ', {
-      timeout: 5000,
+      timeout: 10000,
     }).should('be.visible');
 
     // Go to add new opening period page by pressing the header button
@@ -91,7 +91,7 @@ describe('User adds a new opening period', () => {
 
     // Check that add new opening period form is visible in the new page
     cy.get('[data-test=add-new-opening-period-form]', {
-      timeout: 5000,
+      timeout: 10000,
     }).should('be.visible');
 
     // Start filling the form, first is opening period title

--- a/cypress/integration/DeleteOpeningPeriod.spec.ts
+++ b/cypress/integration/DeleteOpeningPeriod.spec.ts
@@ -30,21 +30,23 @@ describe('User deletes an opening period', () => {
   it('User successfully deletes an opening period', () => {
     // Enter in delete modal by clicking the delete-button
     cy.get('[data-test=resource-opening-periods-list]', {
-      timeout: 5000,
+      timeout: 10000,
     })
       .find(`[data-test="openingPeriodDeleteLink-${dataPeriodId}"]`)
       .click({ log: true });
 
     // Check that delete modal exists
     cy.get('[data-test=modalTitle]', {
-      timeout: 5000,
+      timeout: 10000,
     }).should('exist');
 
     // Click delete modal confirm button
     cy.get('[data-test=modalConfirmButton]').click();
 
     // Check that date-period has disappeared
-    cy.get('[data-test=resource-opening-periods-list]')
+    cy.get('[data-test=resource-opening-periods-list]', {
+      timeout: 10000,
+    })
       .find(`[data-test="openingPeriod-${dataPeriodId}"]`)
       .should('not.exist');
   });

--- a/cypress/integration/EditOpeningPeriod.spec.ts
+++ b/cypress/integration/EditOpeningPeriod.spec.ts
@@ -43,14 +43,14 @@ describe('User edits an opening period', () => {
   it('User successfully edits an opening period', () => {
     // Enter in edit page from resource page
     cy.get('[data-test=resource-opening-periods-list]', {
-      timeout: 5000,
+      timeout: 10000,
     })
       .find(`[data-test="openingPeriodEditLink-${dataPeriodId}"]`)
       .click({ log: true });
 
     // Check that form exists
     cy.get('[data-test=edit-opening-period-form]', {
-      timeout: 5000,
+      timeout: 10000,
     }).should('be.visible');
 
     // Start editing by checking the finnish title
@@ -99,9 +99,8 @@ describe('User edits an opening period', () => {
     }).should('be.visible');
 
     // Check that updated title exists in the date-period's list item on the resource page
-    cy.get(`[data-test="openingPeriod-${dataPeriodId}"]`).should(
-      'contain',
-      newFinnishTitle
-    );
+    cy.get(`[data-test="openingPeriod-${dataPeriodId}"]`, {
+      timeout: 10000,
+    }).should('contain', newFinnishTitle);
   });
 });


### PR DESCRIPTION
The e2e-tests of the application fail quite often. It is not always the same tests that fail everytime but it is always some of the certain group of tests. Usually the tests fail because API does not response within the timeout limits (4000ms - 5000ms). It takes often more than 5000ms from API to respond one or two consecutive requests. 
Now the timeout limits are raised in the most problematic places up to 10000ms.