### PR TITLE
Use react-hook-form's Controller for correct value in the fullday checkbox

### DIFF
--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   ArrayField,
+  Controller,
   DeepMap,
   FieldError,
   useFormContext,
@@ -70,12 +71,11 @@ export default function TimeSpan({
   resourceStateConfig: UiFieldConfig;
   errors: (DeepMap<TimeSpanFormFormat, FieldError> | undefined)[] | undefined;
 }): JSX.Element {
-  const { control, register, getValues } = useFormContext();
+  const { control, register, getValues, watch } = useFormContext();
   const timeSpanNamePrefix = `${namePrefix}[${index}]`;
   const { options: resourceStateOptions } = resourceStateConfig;
   const timeSpanErrors = errors && errors[index];
-
-  const [fullDay, setFullDay] = useState((item.fullDay as unknown) as boolean);
+  const fullDay: boolean = watch(`${timeSpanNamePrefix}.fullDay`);
 
   const getDescriptionValueByLanguage = (language: Language): string => {
     const description = item.description
@@ -195,13 +195,22 @@ export default function TimeSpan({
             placeholder="--.--"
           />
           <div className="time-span-fullday-checkbox-container">
-            <Checkbox
-              id={`${timeSpanNamePrefix}.fullDay`}
-              label="Koko päivä"
+            <Controller
+              render={(field): JSX.Element => (
+                <Checkbox
+                  id={`${timeSpanNamePrefix}.fullDay`}
+                  label="Koko päivä"
+                  name={`${timeSpanNamePrefix}.fullDay`}
+                  onChange={(e): void => {
+                    const eventValue: boolean = e.target.checked;
+                    field.onChange(eventValue);
+                  }}
+                  checked={field.value}
+                />
+              )}
+              control={control}
               name={`${timeSpanNamePrefix}.fullDay`}
-              onChange={(e): void => setFullDay(e.target.checked)}
-              checked={fullDay}
-              ref={register()}
+              defaultValue={item.fullDay || false}
             />
           </div>
         </div>

--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -202,8 +202,7 @@ export default function TimeSpan({
                   label="Koko päivä"
                   name={`${timeSpanNamePrefix}.fullDay`}
                   onChange={(e): void => {
-                    const eventValue: boolean = e.target.checked;
-                    field.onChange(eventValue);
+                    field.onChange(e.target.checked);
                   }}
                   checked={field.value}
                 />

--- a/src/opening-period/time-span/TimeSpan.tsx
+++ b/src/opening-period/time-span/TimeSpan.tsx
@@ -75,7 +75,8 @@ export default function TimeSpan({
   const timeSpanNamePrefix = `${namePrefix}[${index}]`;
   const { options: resourceStateOptions } = resourceStateConfig;
   const timeSpanErrors = errors && errors[index];
-  const fullDay: boolean = watch(`${timeSpanNamePrefix}.fullDay`);
+  const fullDayFieldKey = `${timeSpanNamePrefix}.fullDay`;
+  const fullDay: boolean = watch(fullDayFieldKey);
 
   const getDescriptionValueByLanguage = (language: Language): string => {
     const description = item.description
@@ -198,9 +199,9 @@ export default function TimeSpan({
             <Controller
               render={(field): JSX.Element => (
                 <Checkbox
-                  id={`${timeSpanNamePrefix}.fullDay`}
+                  id={fullDayFieldKey}
                   label="Koko päivä"
-                  name={`${timeSpanNamePrefix}.fullDay`}
+                  name={fullDayFieldKey}
                   onChange={(e): void => {
                     field.onChange(e.target.checked);
                   }}


### PR DESCRIPTION
### Changes
- Use Controller component to wrap HDS Checkbox component (controlled component)
- With Controller component we can ensure that the value of the fullday Checkbox is a boolean and the react-hook-form is using correct name for the value
- React-hook-form [Controlled component](https://react-hook-form.com/api/usecontroller/controller)

### Fixes
- User was not able to add a full day time span to an opening period which already had a timespan