### PR TITLE
Add initial Hauki load tests

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -1,0 +1,15 @@
+# Hauki load testing
+
+Scripts for load testing Hauki API.
+
+## Prerequisities
+
+* [k6](https://k6.io/docs/getting-started/installation) installed
+
+## How to run the tests
+
+This script works as a wrapper for the k6 command and ensures that the proper authentication token is provided in the requests. Thus you can pass all the same parameters as you would do when using k6 directly.
+
+```bash
+    ./run.sh -v 1 -i 1 <SCRIPT>
+```

--- a/k6/hauki-scenarios.js
+++ b/k6/hauki-scenarios.js
@@ -1,0 +1,101 @@
+/* eslint-disable */
+import { check, group, sleep } from 'k6';
+import { Httpx } from 'https://jslib.k6.io/httpx/0.0.1/index.js';
+import { createOpeningHour } from './helpers/mocks.js';
+import commands from './helpers/commands.js';
+import { formatDate, getRandomArbitrary } from './helpers/utils.js';
+
+const {
+  AUTH_PARAMS: authParams,
+  API_URL: apiUrl,
+  HAUKI_RESOURCE: tprekResourceId,
+} = __ENV;
+
+const IDLE_TIME = 10;
+
+const session = new Httpx();
+session.setBaseUrl(`${apiUrl}`);
+session.addHeader('Authorization', `haukisigned ${authParams}`);
+
+const { addNewDatePeriod, viewDatePeriod, viewOffice } = commands(session);
+
+export const options = {
+  thresholds: {
+    http_req_duration: ['p(90) < 2000'],
+  },
+  scenarios: {
+    addOpeningHours: {
+      executor: 'constant-vus',
+      exec: 'addOpeningHours',
+      vus: 5,
+      duration: '1m',
+    },
+    requestOpeningHours: {
+      executor: 'constant-vus',
+      exec: 'requestOpeningHours',
+      vus: 30,
+      duration: '1m',
+    },
+  },
+};
+
+export function setup() {
+  const { id } = session
+    .get(`/resource/${tprekResourceId}/?format=json`)
+    .json();
+
+  session.post('/date_period/', JSON.stringify(createOpeningHour(id)), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  const resources = session.get('/resource/').json();
+
+  return { resourceId: id, resources };
+}
+
+export function addOpeningHours({ resourceId }) {
+  viewOffice(tprekResourceId, resourceId);
+  sleep(getRandomArbitrary(10, IDLE_TIME));
+  addNewDatePeriod(resourceId);
+  viewOffice(tprekResourceId, resourceId);
+}
+
+export function requestOpeningHours({ resources }) {
+  const random = Math.floor(Math.random() * resources.results.length);
+  const resourceId = resources.results[random].id;
+
+  group('Get opening hours', () => {
+    const startDate = new Date();
+    const endDate = new Date();
+    endDate.setDate(startDate.getDate() + 365);
+
+    check(
+      session.get(
+        `/resource/${resourceId}/opening_hours/?start_date=${formatDate(
+          startDate
+        )}&end_date=${formatDate(endDate)}`
+      ),
+      {
+        'Fetching opening hours returns 200': (r) => r.status === 200,
+      }
+    );
+  });
+
+  sleep(getRandomArbitrary(1, 5));
+}
+
+export function teardown({ resourceId }) {
+  const response = session
+    .get(`/date_period/?resource=${resourceId}&end_date_gte=-1d&format=json`)
+    .json();
+
+  const toBeDeleted = response.filter((datePeriod) =>
+    datePeriod.name.fi.includes('load-test')
+  );
+
+  toBeDeleted.forEach((datePeriod) => {
+    session.delete(`/date_period/${datePeriod.id}/`);
+  });
+
+  console.log(`Deleted date periods: ${toBeDeleted.length}`);
+}

--- a/k6/helpers/commands.js
+++ b/k6/helpers/commands.js
@@ -1,0 +1,69 @@
+/* eslint-disable */
+import { check, sleep } from 'k6';
+import { createOpeningHour } from './mocks.js';
+
+const commands = (session) => {
+  const viewOffice = (origId, resourceId) => {
+    session.post(`/resource/${origId}/permission_check/`);
+    session.request('OPTIONS', '/date_period/');
+
+    const response = session.get(
+      `/date_period/?resource=${resourceId}&end_date_gte=-1d&format=json`
+    );
+
+    check(response, {
+      'GET date periods status is 200': (r) => r.status === 200,
+    });
+
+    check(session.get(`/resource/${origId}/?format=json`), {
+      'GET resource status is status 200': (r) => r.status === 200,
+    });
+
+    return response.json();
+  };
+
+  const viewDatePeriod = (resourceId, datePeriodId) => {
+    session.post(`/resource/${resourceId}/permission_check/`);
+
+    check(session.get(`/resource/${resourceId}/?format=json`), {
+      'GET resource status is status 200': (r) => r.status === 200,
+    });
+
+    check(session.get(`/date_period/${datePeriodId}/?format=json`), {
+      'GET date period status is 200': (r) => r.status === 200,
+    });
+
+    session.request('OPTIONS', '/date_period/');
+  };
+
+  const addNewDatePeriod = (resourceId) => {
+    session.post(`/resource/${resourceId}/permission_check/`);
+    session.request('OPTIONS', '/date_period/');
+
+    check(session.get(`/resource/${resourceId}/?format=json`), {
+      'GET resource status is status 200': (r) => r.status === 200,
+    });
+
+    sleep(Math.random(10) + 20);
+
+    const response = session.post(
+      '/date_period/',
+      JSON.stringify(createOpeningHour(resourceId)),
+      {
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    check(response, {
+      'POST date period status is status 201': (r) => r.status === 201,
+    });
+  };
+
+  return {
+    addNewDatePeriod,
+    viewDatePeriod,
+    viewOffice,
+  };
+};
+
+export default commands;

--- a/k6/helpers/mocks.js
+++ b/k6/helpers/mocks.js
@@ -1,0 +1,33 @@
+/* eslint-disable import/prefer-default-export */
+export const createOpeningHour = (resource) => ({
+  resource,
+  name: { fi: `load-test ${new Date().toISOString()}`, sv: '', en: '' },
+  description: { fi: '', sv: '', en: '' },
+  start_date: '2022-01-01',
+  end_date: '2022-12-31',
+  resource_state: 'undefined',
+  override: false,
+  time_span_groups: [
+    {
+      rules: [],
+      time_spans: [
+        {
+          description: { fi: null, sv: null, en: null },
+          end_time: '16:00:00',
+          start_time: '08:00:00',
+          resource_state: 'open',
+          full_day: false,
+          weekdays: [1, 2, 3, 4, 5],
+        },
+        {
+          description: { fi: null, sv: null, en: null },
+          end_time: '18:00:00',
+          start_time: '10:00:00',
+          resource_state: 'open',
+          full_day: false,
+          weekdays: [6],
+        },
+      ],
+    },
+  ],
+});

--- a/k6/helpers/utils.js
+++ b/k6/helpers/utils.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/prefer-default-export */
+export const getRandomArbitrary = (min, max) => {
+  return Math.random() * (max - min) + min;
+};
+
+export const formatDate = (d) => d.toISOString().split('T')[0];

--- a/k6/run.sh
+++ b/k6/run.sh
@@ -1,0 +1,13 @@
+cd $(dirname "$0")
+
+export API_URL=https://hauki-api-test.agw.arodevtest.hel.fi/v1
+# export API_URL=http://localhost:8000/v1
+export HAUKI_USER='dev@hel.fi';
+export HAUKI_RESOURCE='tprek:41835';
+# export HAUKI_RESOURCE='tprek:99';
+
+# 9198
+
+export AUTH_PARAMS=$(node ../scripts/generate-auth-params.js)
+
+k6 run "$@" 

--- a/scripts/generate-auth-params.js
+++ b/scripts/generate-auth-params.js
@@ -1,20 +1,22 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const crypto = require('crypto');
 
-const key = process.env.HAUKI_KEY;
-const username = process.env.HAUKI_USER || 'admin@hel.fi';
-const resource = process.env.HAUKI_RESOURCE || 'tprek:8215';
+// __ENV is for k6
+// eslint-disable-next-line no-undef
+// eslint-disable-next-line dot-notation
+const env = global['__ENV'] || process.env;
+
+const key = env.HAUKI_KEY;
+const username = env.HAUKI_USER || 'admin@hel.fi';
+const resource = env.HAUKI_RESOURCE || 'tprek:8215';
 const organization =
-  process.env.HAUKI_ORGANIZATION ||
-  'tprek:dc7d39db-b35a-4612-a921-1b7b24b0baa3';
-const source = process.env.HAUKI_SOURCE || 'tprek';
+  env.HAUKI_ORGANIZATION || 'tprek:dc7d39db-b35a-4612-a921-1b7b24b0baa3';
+const source = env.HAUKI_SOURCE || 'tprek';
 const now = new Date();
 const createdAt = now.toJSON();
 const validUntil =
-  process.env.HAUKI_VALID_UNTIL ||
-  new Date(now.setDate(now.getDate() + 7)).toJSON();
-const hasOrganizationRights =
-  process.env.HAUKI_HAS_ORGANIZATION_RIGHTS || 'true';
+  env.HAUKI_VALID_UNTIL || new Date(now.setDate(now.getDate() + 7)).toJSON();
+const hasOrganizationRights = env.HAUKI_HAS_ORGANIZATION_RIGHTS || 'true';
 
 const signatureStr = `${source}${username}${createdAt}${validUntil}${organization}${resource}${hasOrganizationRights}`;
 


### PR DESCRIPTION
Adds initial load tests for the project. The load tests are handled with [k6](https://k6.io) which needs to be installed in your system. I added instructions to the README.

To run the load tests you need to execute this command:
```
$ ./k6/run.sh hauki-scenarios.js
```

