### PR TITLE
Feature/holidays forms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { Language } from './common/lib/types';
 import PrivateResourceRoute from './components/router/PrivateResourceRoute';
 import ResourcePage from './pages/ResourcePage';
 import EditOpeningPeriodPage from './pages/EditOpeningPeriodPage';
+import EditHolidaysPage from './pages/EditHolidaysPage';
 
 type OptionalAuthTokens = AuthTokens | undefined;
 
@@ -178,6 +179,22 @@ export default function App(): JSX.Element {
                         datePeriodId={match.params.datePeriodId}
                         parentId={match.params.parentId}
                       />
+                    </Main>
+                  </>
+                )}
+              />
+              <PrivateResourceRoute
+                id="edit-holidays-route"
+                path={['/resource/:id/holidays']}
+                render={({
+                  match,
+                }: RouteComponentProps<{
+                  id: string;
+                }>): ReactElement => (
+                  <>
+                    <HaukiNavigation />
+                    <Main id="main">
+                      <EditHolidaysPage resourceId={match.params.id} />
                     </Main>
                   </>
                 )}

--- a/src/common/helpers/opening-hours-helpers.test.ts
+++ b/src/common/helpers/opening-hours-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   apiDatePeriodToFormValues,
   formValuesToApiDatePeriod,
   getActiveDatePeriod,
+  isHoliday,
 } from './opening-hours-helpers';
 
 const openingHours = [
@@ -410,5 +411,67 @@ describe('opening-hours-helpers', () => {
         },
       ])?.id
     ).toEqual(1039083);
+  });
+
+  describe('isHoliday', () => {
+    const holidays = [
+      {
+        date: '2022-12-31',
+        end_date: '2022-12-31',
+        name: 'Uudenvuodenaatto',
+        start_date: '2022-12-31',
+      },
+      {
+        date: '2023-01-01',
+        end_date: '2023-01-01',
+        name: 'Uudenvuodenpäivä',
+        start_date: '2022-12-31',
+      },
+    ];
+
+    it('should return true when datePeriod is override and matches with holiday', () => {
+      expect(
+        isHoliday(
+          {
+            ...datePeriod,
+            start_date: '2022-12-31',
+            end_date: '2022-12-31',
+            name: { fi: 'Uudenvuodenaatto', sv: '', en: '' },
+            override: true,
+          },
+          holidays
+        )
+      ).toBe(true);
+    });
+
+    it('should return false when datePeriod is override but the range does not match with holiday', () => {
+      expect(
+        isHoliday(
+          {
+            ...datePeriod,
+            start_date: '2022-12-25',
+            end_date: '2022-12-31',
+            name: { fi: 'Uudenvuodenaatto', sv: '', en: '' },
+            override: true,
+          },
+          holidays
+        )
+      ).toBe(false);
+    });
+
+    it('should return false when datePeriod is override and name does not match with holiday', () => {
+      expect(
+        isHoliday(
+          {
+            ...datePeriod,
+            start_date: '2022-12-31',
+            end_date: '2022-12-31',
+            name: { fi: 'Talvi', sv: '', en: '' },
+            override: true,
+          },
+          holidays
+        )
+      ).toBe(false);
+    });
   });
 });

--- a/src/common/helpers/opening-hours-helpers.ts
+++ b/src/common/helpers/opening-hours-helpers.ts
@@ -1,15 +1,15 @@
 import {
   DatePeriod,
   GroupRule,
-  ResourceState,
-  TimeSpan,
-  TimeSpanGroup,
-  Weekdays,
   OpeningHours,
   OpeningHoursFormValues,
   OpeningHoursTimeSpan,
   OpeningHoursTimeSpanGroup,
+  ResourceState,
   Rule,
+  TimeSpan,
+  TimeSpanGroup,
+  Weekdays,
 } from '../lib/types';
 import {
   formatDate,
@@ -131,6 +131,9 @@ export const formValuesToApiDatePeriod = (
     ? transformDateToApiFormat(formValues.startDate)
     : null,
   time_span_groups: toTimeSpanGroups(formValues.openingHours),
+  ...(formValues.resourceState
+    ? { resource_state: formValues.resourceState }
+    : {}),
 });
 
 const weekDaysMatch = (weekdays1: Weekdays, weekdays2: Weekdays): boolean =>
@@ -235,6 +238,8 @@ export const apiDatePeriodToFormValues = (
     (!!datePeriod.start_date && !!datePeriod.end_date) || !!datePeriod.end_date,
   startDate: datePeriod.start_date ? formatDate(datePeriod.start_date) : null,
   openingHours: apiDatePeriodToOpeningHours(datePeriod),
+  id: datePeriod.id,
+  resourceState: datePeriod.resource_state,
 });
 
 const isWithinRange = (date: string, datePeriod: DatePeriod): boolean =>

--- a/src/common/helpers/opening-hours-helpers.ts
+++ b/src/common/helpers/opening-hours-helpers.ts
@@ -1,6 +1,8 @@
+import differenceInMilliseconds from 'date-fns/differenceInMilliseconds';
 import {
   DatePeriod,
   GroupRule,
+  Holiday,
   OpeningHours,
   OpeningHoursFormValues,
   OpeningHoursTimeSpan,
@@ -270,3 +272,22 @@ export const getActiveDatePeriod = (
     return acc;
   }, undefined);
 };
+
+const dayInMilliseconds = 24 * 60 * 60 * 1000;
+
+export const isHoliday = (
+  datePeriod: DatePeriod,
+  holidays: Holiday[]
+): boolean =>
+  !!datePeriod.end_date &&
+  !!datePeriod.start_date &&
+  datePeriod.override &&
+  !!holidays.find(
+    (holiday) =>
+      holiday.date === datePeriod.end_date &&
+      holiday.name === datePeriod.name.fi
+  ) &&
+  differenceInMilliseconds(
+    new Date(datePeriod.end_date),
+    new Date(datePeriod.start_date)
+  ) <= dayInMilliseconds;

--- a/src/common/helpers/preview-helpers.ts
+++ b/src/common/helpers/preview-helpers.ts
@@ -69,24 +69,26 @@ const groupByConsecutiveDays = (
       groups[i] = [];
     });
 
-  return groups
-    .reduce(
-      (result, group) => [
-        ...result,
-        group.reduce((newOpeningHour: PreviewOpeningHours, openingHour) => {
-          return {
-            ...openingHour,
-            weekdays: [...newOpeningHour.weekdays, ...openingHour.weekdays],
-          };
-        }),
-      ],
-      []
-    )
-    .map((openingHour: PreviewOpeningHours) => ({
-      ...openingHour,
-      timeSpans: openingHour.timeSpans.sort(byStartTime),
-    }))
-    .sort(byWeekdays);
+  return groups[0].length > 0
+    ? groups
+        .reduce(
+          (result, group) => [
+            ...result,
+            group.reduce((newOpeningHour: PreviewOpeningHours, openingHour) => {
+              return {
+                ...openingHour,
+                weekdays: [...newOpeningHour.weekdays, ...openingHour.weekdays],
+              };
+            }),
+          ],
+          []
+        )
+        .map((openingHour: PreviewOpeningHours) => ({
+          ...openingHour,
+          timeSpans: openingHour.timeSpans.sort(byStartTime),
+        }))
+        .sort(byWeekdays)
+    : [];
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -303,8 +303,6 @@ export type Choice<T> = {
 };
 
 export type Holiday = {
-  start_date: string;
-  end_date: string;
   date: string;
   name: string;
 };

--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -302,5 +302,6 @@ export type Choice<T> = {
 export type Holiday = {
   start_date: string;
   end_date: string;
+  date: string;
   name: string;
 };

--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -275,11 +275,14 @@ export type OpeningHours = {
 };
 
 export type OpeningHoursFormValues = {
+  id?: number;
   endDate: string | null;
   fixed: boolean;
   name: LanguageStrings;
   openingHours: OpeningHours[];
   startDate: string | null;
+  override?: boolean;
+  resourceState?: ResourceState;
 };
 
 export type PreviewOpeningHours = {

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -153,6 +153,21 @@ async function apiPost<T>({
   });
 }
 
+async function apiPut<T>({
+  path,
+  data = {},
+}: PutRequestParameters): Promise<T> {
+  return request<T>({
+    url: `${apiBaseUrl}/v1${path}/`,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    method: 'put',
+    data,
+    validateStatus,
+  });
+}
+
 async function apiPatch<T>({
   path,
   data = {},
@@ -302,6 +317,12 @@ export default {
   postDatePeriod: (datePeriod: DatePeriod): Promise<DatePeriod> =>
     apiPost<DatePeriod>({
       path: `${datePeriodBasePath}`,
+      data: datePeriod,
+    }),
+
+  putDatePeriod: (datePeriod: DatePeriod): Promise<DatePeriod> =>
+    apiPut<DatePeriod>({
+      path: `${datePeriodBasePath}/${datePeriod.id}`,
       data: datePeriod,
     }),
 

--- a/src/components/holidays-table/HolidaysTable.tsx
+++ b/src/components/holidays-table/HolidaysTable.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
+import { Holiday } from '../../common/lib/types';
 import { formatDate } from '../../common/utils/date-time/format';
 import { getHolidays } from '../../services/holidays';
 import OpeningPeriodAccordion from '../opening-period-accordion/OpeningPeriodAccordion';
 import './HolidaysTable.scss';
+
+export const UpcomingHolidayNotification = ({
+  holiday,
+}: {
+  holiday: Holiday;
+}): JSX.Element => (
+  <>
+    Seuraava juhlapyhä: <strong>{holiday.name}</strong> — Ei poikkeavia
+    aukioloaikoja
+  </>
+);
 
 const HolidaysTable = (): JSX.Element => {
   const holidays = getHolidays();
   return (
     <OpeningPeriodAccordion
       periodName="Juhlapyhien aukioloajat"
-      dateRange={
-        <>
-          Seuraava juhlapyhä: <strong>{holidays[0].name}</strong> — Ei
-          poikkeavia aukioloaikoja
-        </>
-      }
+      dateRange={<UpcomingHolidayNotification holiday={holidays[0]} />}
       editUrl="">
       <div className="holidays-container">
         <h4 id="holidays-title" className="holidays-title">

--- a/src/components/holidays-table/HolidaysTable.tsx
+++ b/src/components/holidays-table/HolidaysTable.tsx
@@ -58,7 +58,7 @@ const HolidaysTable = (): JSX.Element => {
         </div>
         <div role="rowgroup">
           {holidays.map((holiday) => (
-            <div className="holidays-table__row" role="row">
+            <div className="holidays-table__row" role="row" key={holiday.date}>
               <div
                 className="holidays-table__cell holidays-table__cell--name"
                 role="cell">

--- a/src/components/holidays-table/HolidaysTable.tsx
+++ b/src/components/holidays-table/HolidaysTable.tsx
@@ -67,7 +67,7 @@ const HolidaysTable = (): JSX.Element => {
               <div
                 className="holidays-table__cell holidays-table__cell--date"
                 role="cell">
-                {formatDate(holiday.start_date).substring(0, 6)}
+                {formatDate(holiday.date)}
               </div>
               <div
                 className="holidays-table__cell holidays-table__cell--opening-hours"

--- a/src/pages/EditHolidaysPage.scss
+++ b/src/pages/EditHolidaysPage.scss
@@ -1,0 +1,45 @@
+@import 'node_modules/hds-design-tokens/lib/all.scss';
+
+.holidays-page-title {
+  display: flex;
+  align-items: center;
+  font-size: $fontsize-body-m;
+}
+
+.holidays-page-title-addon {
+  margin-left: $spacing-2-xl;
+  font-weight: normal;
+}
+
+.holidays-list {
+  padding: 0;
+}
+
+.holidays-list-item {
+  align-items: flex-start;
+  display: flex;
+  gap: $spacing-l $spacing-m;
+  margin-top: $spacing-m !important;
+  flex-wrap: wrap;
+}
+
+.holiday-list-checkbox {
+  width: 25ch;
+  white-space: nowrap;
+}
+
+.holiday-form {
+  display: flex;
+  gap: $spacing-l $spacing-2-xl;
+  flex: 1;
+  flex-wrap: wrap;
+  margin-top: -1rem;
+}
+
+.holiday-form-actions {
+  margin: $spacing-s 0 $spacing-3-xl;
+}
+
+.holiday-form-fields + .holiday-form-actions {
+  margin-top: $spacing-l;
+}

--- a/src/pages/EditHolidaysPage.scss
+++ b/src/pages/EditHolidaysPage.scss
@@ -28,7 +28,7 @@
   white-space: nowrap;
 }
 
-.holiday-form {
+.holiday-form-container {
   display: flex;
   gap: $spacing-l $spacing-2-xl;
   flex: 1;

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -14,6 +14,7 @@ import {
 import {
   apiDatePeriodToFormValues,
   formValuesToApiDatePeriod,
+  isHoliday,
 } from '../common/helpers/opening-hours-helpers';
 import api from '../common/utils/api/api';
 import { getDatePeriodFormConfig } from '../services/datePeriodFormConfig';
@@ -27,19 +28,6 @@ import TimeSpans from '../components/time-span/TimeSpans';
 
 import { useAppContext } from '../App-context';
 import './EditHolidaysPage.scss';
-
-const filterHolidayPeriods = (
-  periodValues: DatePeriod[],
-  holidays: Holiday[]
-): DatePeriod[] =>
-  periodValues.filter(
-    (datePeriod) =>
-      !!holidays.find(
-        (holiday) =>
-          holiday.date === datePeriod.end_date &&
-          holiday.name === datePeriod.name.fi
-      )
-  );
 
 const getDefaultFormValues = ({
   name,
@@ -266,11 +254,12 @@ export default function EditHolidaysPage({
 
   const fetchValues = useCallback(
     async (resourceIdentifier: number): Promise<void> => {
-      const apiDatePeriods = await api.getDatePeriods(resourceIdentifier);
-      const exceptionPeriods: DatePeriod[] = apiDatePeriods.filter(
-        (period) => period.override
+      const apiDatePeriods: DatePeriod[] = await api.getDatePeriods(
+        resourceIdentifier
       );
-      const holidayPeriods = filterHolidayPeriods(exceptionPeriods, holidays);
+      const holidayPeriods: DatePeriod[] = apiDatePeriods.filter(
+        (apiDatePeriod) => isHoliday(apiDatePeriod, holidays)
+      );
       const holidayValuesList: OpeningHoursFormValues[] = holidayPeriods.map(
         apiDatePeriodToFormValues
       );

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   Checkbox,
-  RadioButton,
   LoadingSpinner,
+  RadioButton,
   SelectionGroup,
 } from 'hds-react';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
@@ -107,15 +107,19 @@ const HolidayForm = ({
 
   const onClosedSelect = (): void => {
     setIsOpen(false);
-    // @ts-ignore
-    setValue(`[${holidayDate}].resourceState`, ResourceState.CLOSED);
+    setValue(holidayDate, {
+      ...valueToUse,
+      resourceState: ResourceState.CLOSED,
+    });
     remove();
   };
 
   const onOpenSelect = (): void => {
     setIsOpen(true);
-    // @ts-ignore
-    setValue(`[${holidayDate}].resourceState`, ResourceState.UNDEFINED);
+    setValue(holidayDate, {
+      ...valueToUse,
+      resourceState: ResourceState.UNDEFINED,
+    });
     remove();
     append({
       timeSpanGroups: [

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -1,0 +1,348 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Checkbox, RadioButton, SelectionGroup } from 'hds-react';
+import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
+import getDay from 'date-fns/getDay';
+import {
+  DatePeriod,
+  Holiday,
+  Language,
+  OpeningHoursFormValues,
+  Resource,
+  ResourceState,
+  UiDatePeriodConfig,
+} from '../common/lib/types';
+import {
+  apiDatePeriodToFormValues,
+  formValuesToApiDatePeriod,
+} from '../common/helpers/opening-hours-helpers';
+import api from '../common/utils/api/api';
+import { getDatePeriodFormConfig } from '../services/datePeriodFormConfig';
+import { getHolidays } from '../services/holidays';
+import { formatDate } from '../common/utils/date-time/format';
+import { PrimaryButton } from '../components/button/Button';
+import { UpcomingHolidayNotification } from '../components/holidays-table/HolidaysTable';
+import ResourceTitle from '../components/resource-title/ResourceTitle';
+import toast from '../components/notification/Toast';
+import TimeSpans from '../components/time-span/TimeSpans';
+
+import { useAppContext } from '../App-context';
+import './EditHolidaysPage.scss';
+
+const filterHolidayPeriods = (
+  periodValues: DatePeriod[],
+  holidays: Holiday[]
+): DatePeriod[] =>
+  periodValues.filter(
+    (datePeriod) =>
+      !!holidays.find(
+        (holiday) =>
+          holiday.date === datePeriod.end_date &&
+          holiday.name === datePeriod.name.fi
+      )
+  );
+
+const getDefaultFormValues = ({
+  name,
+  holidayDate,
+}: {
+  name: string;
+  holidayDate: string;
+}): OpeningHoursFormValues => ({
+  startDate: formatDate(holidayDate),
+  endDate: formatDate(holidayDate),
+  fixed: true,
+  name: { fi: name, sv: '', en: '' },
+  override: true,
+  resourceState: ResourceState.CLOSED,
+  openingHours: [],
+});
+
+const HolidayForm = ({
+  holiday,
+  value,
+  datePeriodConfig,
+  resourceId,
+  onSubmit,
+}: {
+  holiday: Holiday;
+  value?: OpeningHoursFormValues;
+  resourceId: number;
+  datePeriodConfig: UiDatePeriodConfig;
+  onSubmit: () => void;
+}): JSX.Element => {
+  const { name, date: holidayDate } = holiday;
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const openingHoursPrefix = 'openingHours';
+  const fieldNamePrefix = `${openingHoursPrefix}`;
+  const formValue = value || getDefaultFormValues({ name, holidayDate });
+  const [isOpen, setIsOpen] = useState<boolean>(
+    formValue && formValue.resourceState
+      ? formValue.resourceState !== ResourceState.CLOSED
+      : false
+  );
+
+  console.log(formValue);
+
+  const form = useForm<OpeningHoursFormValues>({
+    defaultValues: formValue,
+    shouldUnregister: false,
+  });
+  const { control, setValue } = form;
+  const { remove, append } = useFieldArray({
+    name: fieldNamePrefix,
+    control,
+  });
+
+  const onClosedSelect = (): void => {
+    setIsOpen(false);
+    setValue('resourceState', ResourceState.CLOSED);
+    remove();
+  };
+
+  const onOpenSelect = (): void => {
+    setIsOpen(true);
+    setValue('resourceState', undefined);
+    remove();
+    append({
+      timeSpanGroups: [
+        {
+          timeSpans: [
+            {
+              resource_state: ResourceState.OPEN,
+            },
+          ],
+        },
+      ],
+      weekdays: [getDay(new Date(holidayDate))],
+    });
+  };
+
+  const {
+    resourceState: { options: resourceStates = [] },
+  } = datePeriodConfig;
+
+  const save = (values: OpeningHoursFormValues): void => {
+    if (!resourceId) {
+      throw new Error('Resource not found');
+    }
+    setIsSaving(true);
+    const apiMethod = values.id ? api.putDatePeriod : api.postDatePeriod;
+    console.log({
+      ...formValuesToApiDatePeriod(resourceId, values, values.id),
+      override: true,
+    });
+
+    apiMethod({
+      ...formValuesToApiDatePeriod(resourceId, values, values.id),
+      override: true,
+    })
+      .then(() => {
+        toast.success({
+          dataTestId: 'holiday-form-success',
+          label: 'Tallennus onnistui',
+          text: `${name} aukiolon tallennus onnistui`,
+        });
+
+        onSubmit();
+      })
+      .catch(() => {
+        toast.error({
+          dataTestId: 'holiday-form-success-error',
+          label: 'Tallennus epäonnistui',
+          text: `${name} aukiolon tallennus epäonnistui`,
+        });
+      })
+      .finally(() => setIsSaving(false));
+  };
+
+  return (
+    <div className="holiday-form">
+      <SelectionGroup label="">
+        <RadioButton
+          id={`${holidayDate}-closed-state-checkbox`}
+          name={`${holidayDate}-closed-state-checkbox`}
+          checked={!isOpen}
+          label="Suljettu koko päivän"
+          onChange={(): void => onClosedSelect()}
+        />
+        <RadioButton
+          id={`${holidayDate}-open-state-checkbox`}
+          name={`${holidayDate}-open-state-checkbox`}
+          checked={isOpen}
+          label="Voimassa tietyn ajan"
+          onChange={(): void => onOpenSelect()}
+        />
+      </SelectionGroup>
+      <FormProvider {...form}>
+        <form onSubmit={form.handleSubmit(save)}>
+          {isOpen && (
+            <div className="holiday-form-fields">
+              <TimeSpans
+                resourceStates={resourceStates}
+                namePrefix={`${fieldNamePrefix}[0].timeSpanGroups[0].timeSpans`}
+              />
+            </div>
+          )}
+          <div className="holiday-form-actions">
+            <PrimaryButton
+              dataTest="submit-opening-hours-button"
+              isLoading={isSaving}
+              loadingText="Tallentaa poikkeusaukioloa"
+              type="submit">
+              Tallenna
+            </PrimaryButton>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+};
+
+const HolidayListItem = ({
+  holiday,
+  value,
+  resourceId,
+  datePeriodConfig,
+  onSubmit,
+}: {
+  holiday: Holiday;
+  value?: OpeningHoursFormValues;
+  resourceId: number;
+  datePeriodConfig: UiDatePeriodConfig;
+  onSubmit: () => void;
+}): JSX.Element => {
+  const [checked, setChecked] = useState<boolean>(!!value);
+  const { name, date } = holiday;
+
+  return (
+    <li className="holidays-list-item" key={date}>
+      <Checkbox
+        id={date}
+        label={`${name}   ${formatDate(date)}`}
+        className="holiday-list-checkbox"
+        checked={checked}
+        onChange={(): void => setChecked(!checked)}
+      />
+      {checked && (
+        <HolidayForm
+          holiday={holiday}
+          value={value}
+          resourceId={resourceId}
+          datePeriodConfig={datePeriodConfig}
+          onSubmit={onSubmit}
+        />
+      )}
+    </li>
+  );
+};
+
+export default function EditHolidaysPage({
+  resourceId,
+}: {
+  resourceId: string;
+}): JSX.Element {
+  const [resource, setResource] = useState<Resource>();
+  const [holidayValues, setHolidayValues] = useState<
+    OpeningHoursFormValues[] | undefined
+  >();
+  const [datePeriodConfig, setDatePeriodConfig] = useState<
+    UiDatePeriodConfig
+  >();
+  const { language = Language.FI } = useAppContext();
+  const [holidays, setHolidays] = useState<Holiday[]>([]);
+
+  useEffect((): void => {
+    const fetchData = async (): Promise<void> => {
+      try {
+        const [apiResource, uiDatePeriodOptions] = await Promise.all([
+          api.getResource(resourceId),
+          getDatePeriodFormConfig(),
+        ]);
+        setHolidays(getHolidays());
+        setResource(apiResource);
+        setDatePeriodConfig(uiDatePeriodOptions);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Fetching data failed in holidays page:', e);
+      }
+    };
+
+    fetchData();
+  }, [resourceId]);
+
+  const fetchValues = useCallback(
+    async (resourceIdentifier: number): Promise<void> => {
+      const apiDatePeriods = await api.getDatePeriods(resourceIdentifier);
+      const exceptionPeriods: DatePeriod[] = apiDatePeriods.filter(
+        (period) => period.override
+      );
+      const holidayPeriods = filterHolidayPeriods(exceptionPeriods, holidays);
+      const holidayValuesList: OpeningHoursFormValues[] = holidayPeriods.map(
+        apiDatePeriodToFormValues
+      );
+      setHolidayValues(holidayValuesList);
+    },
+    [holidays]
+  );
+
+  useEffect((): void => {
+    const fetchHolidayValues = async (): Promise<void> => {
+      try {
+        if (resource) {
+          fetchValues(resource.id);
+        }
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(
+          'Fetching data failed in holidays page - apiDatePeriods:',
+          e
+        );
+      }
+    };
+
+    fetchHolidayValues();
+  }, [fetchValues, holidays, resource]);
+
+  if (!resource || !datePeriodConfig || !holidayValues) {
+    return <h1>Ladataan...</h1>;
+  }
+
+  return (
+    <>
+      <ResourceTitle language={language} resource={resource} />
+      <div className="holidays-page card">
+        <div className="holidays-page-title">
+          <h3>Juhlapyhien aukioloajat</h3>
+          <span className="holidays-page-title-addon">
+            {holidays.length && (
+              <UpcomingHolidayNotification holiday={holidays[0]} />
+            )}
+          </span>
+        </div>
+        <p>
+          Jos lisäät listassa olevalle juhlapyhälle poikkeavan aukioloajan, se
+          on voimassa toistaiseksi. Muista tarkistaa vuosittain, että tieto
+          pitää yhä paikkansa.
+        </p>
+        <ul className="holidays-list">
+          {holidays.map((holiday) => (
+            <HolidayListItem
+              key={holiday.date}
+              holiday={holiday}
+              datePeriodConfig={datePeriodConfig}
+              resourceId={resource.id}
+              value={
+                holidayValues
+                  ? holidayValues.find(
+                      (value) => value.name.fi === holiday.name
+                    )
+                  : undefined
+              }
+              onSubmit={() => fetchValues(resource.id)}
+            />
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -362,8 +362,8 @@ export default function EditHolidaysPage({
   };
 
   const update = async (values: OpeningHoursFormValues): Promise<void> => {
-    if (!resource) {
-      throw new Error('Resource not found');
+    if (!resource || !values || !values.id) {
+      throw new Error('Resource or period not found');
     }
 
     return api

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -146,7 +146,7 @@ const HolidayForm = ({
   };
 
   return (
-    <div className="holiday-form">
+    <>
       <SelectionGroup label="">
         <RadioButton
           id={`${holidayDate}-closed-state-checkbox`}
@@ -189,7 +189,7 @@ const HolidayForm = ({
           </div>
         </form>
       </FormProvider>
-    </div>
+    </>
   );
 };
 
@@ -263,7 +263,7 @@ const HolidayListItem = ({
           Poistetaan aukiolojaksoa..
         </>
       ) : (
-        <>
+        <div className="holiday-form-container" key={holiday.date}>
           {checked && (
             <HolidayForm
               holiday={holiday}
@@ -272,7 +272,7 @@ const HolidayListItem = ({
               actions={actions}
             />
           )}
-        </>
+        </div>
       )}
     </li>
   );

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -272,7 +272,7 @@ export default function EditHolidaysPage({
     const fetchHolidayValues = async (): Promise<void> => {
       try {
         if (resource) {
-          fetchValues(resource.id);
+          await fetchValues(resource.id);
         }
       } catch (e) {
         // eslint-disable-next-line no-console
@@ -321,7 +321,7 @@ export default function EditHolidaysPage({
                     )
                   : undefined
               }
-              onSubmit={() => fetchValues(resource.id)}
+              onSubmit={(): Promise<void> => fetchValues(resource.id)}
             />
           ))}
         </ul>

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -45,6 +45,12 @@ const getDefaultFormValues = ({
   openingHours: [],
 });
 
+const getNumberOfTheWeekday = (date: string): number => {
+  // Date-fns returns index and it starts from Sunday.
+  const dateFnsWeekdayIndex: number = getDay(new Date(date));
+  return dateFnsWeekdayIndex === 0 ? 7 : dateFnsWeekdayIndex;
+};
+
 const HolidayForm = ({
   holiday,
   value,
@@ -99,7 +105,7 @@ const HolidayForm = ({
           ],
         },
       ],
-      weekdays: [getDay(new Date(holidayDate))],
+      weekdays: [getNumberOfTheWeekday(holidayDate)],
     });
   };
 

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -81,8 +81,6 @@ const HolidayForm = ({
       : false
   );
 
-  console.log(formValue);
-
   const form = useForm<OpeningHoursFormValues>({
     defaultValues: formValue,
     shouldUnregister: false,
@@ -127,10 +125,6 @@ const HolidayForm = ({
     }
     setIsSaving(true);
     const apiMethod = values.id ? api.putDatePeriod : api.postDatePeriod;
-    console.log({
-      ...formValuesToApiDatePeriod(resourceId, values, values.id),
-      override: true,
-    });
 
     apiMethod({
       ...formValuesToApiDatePeriod(resourceId, values, values.id),

--- a/src/pages/ResourcePage.test.tsx
+++ b/src/pages/ResourcePage.test.tsx
@@ -132,11 +132,14 @@ describe(`<ResourcePage />`, () => {
       .spyOn(api, 'getParentResourcesByChildId')
       .mockImplementation(() => Promise.resolve([testParentResource]));
 
-    jest
-      .spyOn(holidays, 'getHolidays')
-      .mockImplementation(() => [
-        { name: 'Juhannus', start_date: '2022-06-24', end_date: '2022-06-24' },
-      ]);
+    jest.spyOn(holidays, 'getHolidays').mockImplementation(() => [
+      {
+        name: 'Juhannus',
+        start_date: '2022-06-24',
+        end_date: '2022-06-24',
+        date: '2022-06-24',
+      },
+    ]);
   });
   afterEach(() => {
     jest.clearAllMocks();

--- a/src/pages/ResourcePage.test.tsx
+++ b/src/pages/ResourcePage.test.tsx
@@ -135,8 +135,6 @@ describe(`<ResourcePage />`, () => {
     jest.spyOn(holidays, 'getHolidays').mockImplementation(() => [
       {
         name: 'Juhannus',
-        start_date: '2022-06-24',
-        end_date: '2022-06-24',
         date: '2022-06-24',
       },
     ]);

--- a/src/services/holidays.ts
+++ b/src/services/holidays.ts
@@ -20,10 +20,8 @@ export const getHolidays = (): Holiday[] => {
     .map((year) => hd.getHolidays(year))
     .flat()
     .map((date) => ({
-      start_date: formatDate(date.start),
-      end_date: formatDate(date.end),
       date: date.date.split(' ')[0],
       name: date.name,
     }))
-    .filter((date) => date.start_date >= start && date.end_date <= end);
+    .filter((date) => date.date >= start && date.date <= end);
 };

--- a/src/services/holidays.ts
+++ b/src/services/holidays.ts
@@ -22,6 +22,7 @@ export const getHolidays = (): Holiday[] => {
     .map((date) => ({
       start_date: formatDate(date.start),
       end_date: formatDate(date.end),
+      date: date.date.split(' ')[0],
       name: date.name,
     }))
     .filter((date) => date.start_date >= start && date.end_date <= end);


### PR DESCRIPTION
## Description 
- Add holidays page for editing resource's single holidays in one place
- Added a few missing date period properties to OpeningHourFormValues
- Fix to opening-hour-helper to accept a Date Period without timeSpanGroups (Date Periods can be always open)
 
 ## Motivation
 - We do not know yet but it might be easier for the user to view yearly holidays on one page. Now we have something for the end users to test
 
 ## How is this tested?
 - Locally on the dev machine
 - unit tests
 