### PR TITLE
Add display stored holidays

### DIFF
--- a/src/components/holidays-table/HolidaysTable.scss
+++ b/src/components/holidays-table/HolidaysTable.scss
@@ -79,8 +79,12 @@
   }
 }
 
-.upcoming-holidays {
-  align-items: center;
-  display: flex;
-  gap: $spacing-s;
+.upcoming-holidays-divider {
+  display: none;
+}
+
+@media screen and (min-width: $breakpoint-l) {
+  .upcoming-holidays-divider {
+    display: revert;
+  }
 }

--- a/src/components/holidays-table/HolidaysTable.scss
+++ b/src/components/holidays-table/HolidaysTable.scss
@@ -78,3 +78,9 @@
     grid-column: auto;
   }
 }
+
+.upcoming-holidays {
+  align-items: center;
+  display: flex;
+  gap: $spacing-s;
+}

--- a/src/components/holidays-table/HolidaysTable.scss
+++ b/src/components/holidays-table/HolidaysTable.scss
@@ -78,13 +78,3 @@
     grid-column: auto;
   }
 }
-
-.upcoming-holidays-divider {
-  display: none;
-}
-
-@media screen and (min-width: $breakpoint-l) {
-  .upcoming-holidays-divider {
-    display: revert;
-  }
-}

--- a/src/components/holidays-table/HolidaysTable.tsx
+++ b/src/components/holidays-table/HolidaysTable.tsx
@@ -20,17 +20,17 @@ export const UpcomingHolidayNotification = ({
   datePeriods: DatePeriod[];
   holiday: Holiday;
 }): JSX.Element => (
-  <div className="upcoming-holidays">
+  <>
     <span>
       Seuraava juhlapyhä: <strong>{holiday.name}</strong>
     </span>
-    <span>—</span>
+    <span className="upcoming-holidays-divider">—</span>
     <HolidayOpeningHours
       datePeriodConfig={datePeriodConfig}
       datePeriods={datePeriods}
       holiday={holiday}
     />
-  </div>
+  </>
 );
 
 const HolidayOpeningHours = ({

--- a/src/components/holidays-table/HolidaysTable.tsx
+++ b/src/components/holidays-table/HolidaysTable.tsx
@@ -3,6 +3,7 @@ import { isHoliday } from '../../common/helpers/opening-hours-helpers';
 import {
   DatePeriod,
   Holiday,
+  ResourceState,
   UiDatePeriodConfig,
 } from '../../common/lib/types';
 import { formatDate } from '../../common/utils/date-time/format';
@@ -11,14 +12,25 @@ import OpeningPeriodAccordion from '../opening-period-accordion/OpeningPeriodAcc
 import './HolidaysTable.scss';
 
 export const UpcomingHolidayNotification = ({
+  datePeriodConfig,
+  datePeriods,
   holiday,
 }: {
+  datePeriodConfig?: UiDatePeriodConfig;
+  datePeriods: DatePeriod[];
   holiday: Holiday;
 }): JSX.Element => (
-  <>
-    Seuraava juhlapyhä: <strong>{holiday.name}</strong> — Ei poikkeavia
-    aukioloaikoja
-  </>
+  <div className="upcoming-holidays">
+    <span>
+      Seuraava juhlapyhä: <strong>{holiday.name}</strong>
+    </span>
+    <span>—</span>
+    <HolidayOpeningHours
+      datePeriodConfig={datePeriodConfig}
+      datePeriods={datePeriods}
+      holiday={holiday}
+    />
+  </div>
 );
 
 const HolidayOpeningHours = ({
@@ -34,17 +46,19 @@ const HolidayOpeningHours = ({
 
   if (datePeriod) {
     return (
-      <>
-        {datePeriod.time_span_groups.map((timeSpanGroup) =>
-          timeSpanGroup.time_spans.map((timeSpan) => (
-            <TimeSpan
-              key={timeSpan.id}
-              resourceStates={datePeriodConfig?.resourceState.options || []}
-              timeSpan={timeSpan}
-            />
-          ))
-        )}
-      </>
+      <div>
+        {datePeriod.resource_state === ResourceState.CLOSED
+          ? 'Suljettu'
+          : datePeriod.time_span_groups.map((timeSpanGroup) =>
+              timeSpanGroup.time_spans.map((timeSpan) => (
+                <TimeSpan
+                  key={timeSpan.id}
+                  resourceStates={datePeriodConfig?.resourceState.options || []}
+                  timeSpan={timeSpan}
+                />
+              ))
+            )}
+      </div>
     );
   }
 
@@ -64,7 +78,13 @@ const HolidaysTable = ({
 }): JSX.Element => (
   <OpeningPeriodAccordion
     periodName="Juhlapyhien aukioloajat"
-    dateRange={<UpcomingHolidayNotification holiday={holidays[0]} />}
+    dateRange={
+      <UpcomingHolidayNotification
+        datePeriodConfig={datePeriodConfig}
+        datePeriods={datePeriods}
+        holiday={holidays[0]}
+      />
+    }
     editUrl={`/resource/${resourceId}/holidays`}>
     <div className="holidays-container">
       <h4 id="holidays-title" className="holidays-title">

--- a/src/components/holidays-table/HolidaysTable.tsx
+++ b/src/components/holidays-table/HolidaysTable.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
-import { Holiday } from '../../common/lib/types';
+import { isHoliday } from '../../common/helpers/opening-hours-helpers';
+import {
+  DatePeriod,
+  Holiday,
+  UiDatePeriodConfig,
+} from '../../common/lib/types';
 import { formatDate } from '../../common/utils/date-time/format';
-import { getHolidays } from '../../services/holidays';
+import { TimeSpan } from '../opening-hours-preview/OpeningHoursPreview';
 import OpeningPeriodAccordion from '../opening-period-accordion/OpeningPeriodAccordion';
 import './HolidaysTable.scss';
 
@@ -16,70 +21,109 @@ export const UpcomingHolidayNotification = ({
   </>
 );
 
-const HolidaysTable = ({ resourceId }: { resourceId: number }): JSX.Element => {
-  const holidays = getHolidays();
-  return (
-    <OpeningPeriodAccordion
-      periodName="Juhlapyhien aukioloajat"
-      dateRange={<UpcomingHolidayNotification holiday={holidays[0]} />}
-      editUrl={`/resource/${resourceId}/holidays`}>
-      <div className="holidays-container">
-        <h4 id="holidays-title" className="holidays-title">
-          Seuraavat juhlapyhät
-        </h4>
-        <p id="holidays-description" className="holidays-description">
-          Muista tarkistaa juhlapyhien aikataulut vuosittain – esimerkiksi
-          pääsiäisen juhlapyhien ajankohta vaihtelee.
-        </p>
-      </div>
-      <div
-        className="holidays-table"
-        role="table"
-        aria-labelledby="holidays-title"
-        aria-describedby="holidays-description">
-        <div role="rowgroup">
+const HolidayOpeningHours = ({
+  datePeriods,
+  holiday,
+  datePeriodConfig,
+}: {
+  datePeriodConfig?: UiDatePeriodConfig;
+  datePeriods: DatePeriod[];
+  holiday: Holiday;
+}): JSX.Element => {
+  const datePeriod = datePeriods.find((dp) => isHoliday(dp, [holiday]));
+
+  if (datePeriod) {
+    return (
+      <>
+        {datePeriod.time_span_groups.map((timeSpanGroup) =>
+          timeSpanGroup.time_spans.map((timeSpan) => (
+            <TimeSpan
+              key={timeSpan.id}
+              resourceStates={datePeriodConfig?.resourceState.options || []}
+              timeSpan={timeSpan}
+            />
+          ))
+        )}
+      </>
+    );
+  }
+
+  return <>Ei poikkeavia aukioloja</>;
+};
+
+const HolidaysTable = ({
+  datePeriodConfig,
+  datePeriods,
+  holidays,
+  resourceId,
+}: {
+  datePeriodConfig?: UiDatePeriodConfig;
+  datePeriods: DatePeriod[];
+  holidays: Holiday[];
+  resourceId: number;
+}): JSX.Element => (
+  <OpeningPeriodAccordion
+    periodName="Juhlapyhien aukioloajat"
+    dateRange={<UpcomingHolidayNotification holiday={holidays[0]} />}
+    editUrl={`/resource/${resourceId}/holidays`}>
+    <div className="holidays-container">
+      <h4 id="holidays-title" className="holidays-title">
+        Seuraavat juhlapyhät
+      </h4>
+      <p id="holidays-description" className="holidays-description">
+        Muista tarkistaa juhlapyhien aikataulut vuosittain – esimerkiksi
+        pääsiäisen juhlapyhien ajankohta vaihtelee.
+      </p>
+    </div>
+    <div
+      className="holidays-table"
+      role="table"
+      aria-labelledby="holidays-title"
+      aria-describedby="holidays-description">
+      <div role="rowgroup">
+        <div className="holidays-table__header holidays-table__row" role="row">
+          <div className="holidays-table__header-cell" role="columnheader">
+            Juhlapyhä
+          </div>
           <div
-            className="holidays-table__header holidays-table__row"
-            role="row">
-            <div className="holidays-table__header-cell" role="columnheader">
-              Juhlapyhä
-            </div>
-            <div
-              className="holidays-table__header-cell holidays-table__cell--date"
-              role="columnheader">
-              Päivämäärä
-            </div>
-            <div
-              className="holidays-table__header-cell holidays-table__header-cell--opening-hours"
-              role="columnheader">
-              Aukiolo
-            </div>
+            className="holidays-table__header-cell holidays-table__cell--date"
+            role="columnheader">
+            Päivämäärä
+          </div>
+          <div
+            className="holidays-table__header-cell holidays-table__header-cell--opening-hours"
+            role="columnheader">
+            Aukiolo
           </div>
         </div>
-        <div role="rowgroup">
-          {holidays.map((holiday) => (
-            <div className="holidays-table__row" role="row" key={holiday.date}>
-              <div
-                className="holidays-table__cell holidays-table__cell--name"
-                role="cell">
-                {holiday.name}
-              </div>
-              <div
-                className="holidays-table__cell holidays-table__cell--date"
-                role="cell">
-                {formatDate(holiday.date)}
-              </div>
-              <div
-                className="holidays-table__cell holidays-table__cell--opening-hours"
-                role="cell">
-                Ei poikkeavia aukioloja
-              </div>
-            </div>
-          ))}
-        </div>
       </div>
-    </OpeningPeriodAccordion>
-  );
-};
+      <div role="rowgroup">
+        {holidays.map((holiday) => (
+          <div className="holidays-table__row" role="row" key={holiday.date}>
+            <div
+              className="holidays-table__cell holidays-table__cell--name"
+              role="cell">
+              {holiday.name}
+            </div>
+            <div
+              className="holidays-table__cell holidays-table__cell--date"
+              role="cell">
+              {formatDate(holiday.date)}
+            </div>
+            <div
+              className="holidays-table__cell holidays-table__cell--opening-hours"
+              role="cell">
+              <HolidayOpeningHours
+                datePeriodConfig={datePeriodConfig}
+                datePeriods={datePeriods}
+                holiday={holiday}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </OpeningPeriodAccordion>
+);
 
 export default HolidaysTable;

--- a/src/components/opening-hours-preview/OpeningHoursPreview.scss
+++ b/src/components/opening-hours-preview/OpeningHoursPreview.scss
@@ -79,7 +79,7 @@ td::first-letter {
   background: #fafafb;
 }
 
-.opening-hours-preview-table__opening-hours {
+.opening-hours-preview-time-span-container {
   display: grid;
   grid-template-columns: 120px 1fr;
   gap: 5px;

--- a/src/components/opening-period-accordion/OpeningPeriodAccordion.tsx
+++ b/src/components/opening-period-accordion/OpeningPeriodAccordion.tsx
@@ -72,7 +72,7 @@ const OpeningPeriodAccordion = ({
           )}
         </div>
         <div className="opening-period-dates opening-period-header-column">
-          <div>{dateRange}</div>
+          {dateRange}
           {isActive && (
             <StatusLabel className="opening-period-dates-status" type="info">
               Voimassa nyt

--- a/src/components/resource-opening-hours/opening-period/OpeningPeriod.scss
+++ b/src/components/resource-opening-hours/opening-period/OpeningPeriod.scss
@@ -4,7 +4,7 @@
   font-family: HelsinkiGrotesk-Regular, Arial, sans-serif;
   box-sizing: border-box;
   background-color: var(--opening-period-background-color);
-  padding: 6px $spacing-m;
+  padding: $spacing-xs $spacing-m;
 
   h4 {
     font-size: $fontsize-body-l;

--- a/src/components/time-span/TimeSpan.scss
+++ b/src/components/time-span/TimeSpan.scss
@@ -3,14 +3,13 @@
 .time-span {
   align-items: flex-end;
   display: grid;
-  gap: 1.5rem 0;
+  gap: 1rem;
   grid-template-columns: 1fr 1fr;
 }
 
 @media screen and (min-width: $breakpoint-s) {
   .time-span {
-    gap: 1.5rem;
-    grid-template-columns: 1fr 70px 1fr 1fr;
+    grid-template-columns: 1fr 70px auto 1fr;
   }
 }
 
@@ -65,6 +64,13 @@
   display: flex;
   align-items: center;
   gap: 5px;
+  grid-column: 1/3;
+}
+
+@media screen and (min-width: $breakpoint-m) {
+  .time-span__range {
+    grid-column: auto;
+  }
 }
 
 .time-span__range-divider {

--- a/src/components/time-span/TimeSpan.tsx
+++ b/src/components/time-span/TimeSpan.tsx
@@ -103,7 +103,7 @@ const TimeSpan = ({
           id={getUiId([namePrefix, 'start-time'])}
           hoursLabel="tunnit"
           minutesLabel="minuutit"
-          label="Alkaen"
+          label="Alkaen klo"
           name={`${namePrefix}.start_time`}
           required
           value={item?.start_time || ''}
@@ -115,7 +115,7 @@ const TimeSpan = ({
           id={getUiId([namePrefix, 'end-time'])}
           hoursLabel="tunnit"
           minutesLabel="minuutit"
-          label="Päättyen"
+          label="Päättyen klo"
           name={`${namePrefix}.end_time`}
           required
           value={item?.end_time || ''}

--- a/src/components/time-span/TimeSpans.scss
+++ b/src/components/time-span/TimeSpans.scss
@@ -1,3 +1,9 @@
+.time-spans {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .add-time-span-button {
   margin-left: -25px;
 }

--- a/src/components/time-span/TimeSpans.tsx
+++ b/src/components/time-span/TimeSpans.tsx
@@ -41,7 +41,7 @@ const TimeSpans = ({
   }, [fields, firstTimeSpanResourceState, namePrefix, remove]);
 
   return (
-    <>
+    <div className="time-spans">
       {fields.map((field, i) => (
         <TimeSpan
           key={field.id}
@@ -75,7 +75,7 @@ const TimeSpans = ({
           </SupplementaryButton>
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/EditHolidaysPage.scss
+++ b/src/pages/EditHolidaysPage.scss
@@ -4,11 +4,8 @@
   display: flex;
   align-items: center;
   font-size: $fontsize-body-m;
-}
-
-.holidays-page-title-addon {
-  margin-left: $spacing-2-xl;
-  font-weight: normal;
+  flex-wrap: wrap;
+  gap: $spacing-s $spacing-l;
 }
 
 .holidays-list {

--- a/src/pages/EditHolidaysPage.scss
+++ b/src/pages/EditHolidaysPage.scss
@@ -6,6 +6,16 @@
   font-size: $fontsize-body-m;
   flex-wrap: wrap;
   gap: $spacing-s $spacing-l;
+
+  .upcoming-holidays-divider {
+    display: none;
+  }
+
+  @media screen and (min-width: $breakpoint-l) {
+    .upcoming-holidays-divider {
+      display: revert;
+    }
+  }
 }
 
 .holidays-list {

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -438,7 +438,7 @@ export default function EditHolidaysPage({
       <div className="holidays-page card">
         <div className="holidays-page-title">
           <h3>Juhlapyhien aukioloajat</h3>
-          {holidays.length && (
+          {holidays.length > 0 && (
             <UpcomingHolidayNotification
               datePeriodConfig={datePeriodConfig}
               datePeriods={holidayPeriods}

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -438,15 +438,13 @@ export default function EditHolidaysPage({
       <div className="holidays-page card">
         <div className="holidays-page-title">
           <h3>Juhlapyhien aukioloajat</h3>
-          <span className="holidays-page-title-addon">
-            {holidays.length && (
-              <UpcomingHolidayNotification
-                datePeriodConfig={datePeriodConfig}
-                datePeriods={holidayPeriods}
-                holiday={holidays[0]}
-              />
-            )}
-          </span>
+          {holidays.length && (
+            <UpcomingHolidayNotification
+              datePeriodConfig={datePeriodConfig}
+              datePeriods={holidayPeriods}
+              holiday={holidays[0]}
+            />
+          )}
         </div>
         <p>
           Jos lisäät listassa olevalle juhlapyhälle poikkeavan aukioloajan, se

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -296,6 +296,7 @@ export default function EditHolidaysPage({
   >();
   const { language = Language.FI } = useAppContext();
   const [holidays, setHolidays] = useState<Holiday[]>([]);
+  const [holidayPeriods, setHolidayPeriods] = useState<DatePeriod[]>([]);
 
   useEffect((): void => {
     const fetchData = async (): Promise<void> => {
@@ -321,10 +322,11 @@ export default function EditHolidaysPage({
       const apiDatePeriods: DatePeriod[] = await api.getDatePeriods(
         resourceIdentifier
       );
-      const holidayPeriods: DatePeriod[] = apiDatePeriods.filter(
+      const holidayPeriodsResult: DatePeriod[] = apiDatePeriods.filter(
         (apiDatePeriod) => isHoliday(apiDatePeriod, holidays)
       );
-      const holidayValuesList: OpeningHoursFormValues[] = holidayPeriods.map(
+      setHolidayPeriods(holidayPeriodsResult);
+      const holidayValuesList: OpeningHoursFormValues[] = holidayPeriodsResult.map(
         apiDatePeriodToFormValues
       );
       setHolidayValues(holidayValuesList);
@@ -451,7 +453,11 @@ export default function EditHolidaysPage({
           <h3>Juhlapyhien aukioloajat</h3>
           <span className="holidays-page-title-addon">
             {holidays.length && (
-              <UpcomingHolidayNotification holiday={holidays[0]} />
+              <UpcomingHolidayNotification
+                datePeriodConfig={datePeriodConfig}
+                datePeriods={holidayPeriods}
+                holiday={holidays[0]}
+              />
             )}
           </span>
         </div>


### PR DESCRIPTION
### Description
- Display stored holidays` opening hours on the resource page
- Display stored holiday`s opening hours in the holidays table row
- Display stored holiday`s opening hours in the edit holidays title
- Fix duplicate key issue when deleting time span
- Enhance edit holidays page's title in mobile

### Motivation
Now the user can see the stored opening hours for each holiday

### How is this tested?
Locally on the dev machine