### PR TITLE
Fix build docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,6 @@
 !yarn.lock
 !tsconfig.json
 !LICENSE
+!.eslintrc.js
+!tsconfig.eslint.json
+!.prettierrc.json

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,6 +82,8 @@ module.exports = {
     'func-names': 0,
     'react/no-unstable-nested-components': 0,
     'react/jsx-no-useless-fragment': 0,
+    'import/no-anonymous-default-export': 0,
+    'testing-library/no-await-sync-query': 0,
   },
   globals: {
     cy: true,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@sentry/react": "^6.11.0",
     "@sentry/tracing": "^6.11.0",
     "@testing-library/react": "^11.0.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^12.2.2",
     "@types/cypress": "^1.1.3",
     "@types/cypress-axe": "^0.8.0",
     "@types/enzyme": "^3.10.6",
@@ -38,9 +38,9 @@
     "react-dom": "^17.0.1",
     "react-hook-form": "^7.30.0",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^4.0.0",
     "react-test-renderer": "^16.13.1",
-    "typescript": "4.4.4",
+    "typescript": "^4.4.0 <4.5.0",
     "use-deep-compare-effect": "^1.4.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,10 +2227,12 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
-"@testing-library/user-event@^7.1.2":
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-7.2.1.tgz#2ad4e844175a3738cb9e7064be5ea070b8863a1c"
-  integrity sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA==
+"@testing-library/user-event@^12.2.2":
+  version "12.8.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.8.3.tgz#1aa3ed4b9f79340a1e1836bc7f57c501e838704a"
+  integrity sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 "@types/aria-query@^4.2.0":
   version "4.2.0"
@@ -12145,7 +12147,7 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-scripts@4.0.3:
+react-scripts@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-4.0.3.tgz#b1cafed7c3fa603e7628ba0f187787964cb5d345"
   integrity sha512-S5eO4vjUzUisvkIPB7jVsKtuH2HhWcASREYWHAQ1FP5HyCv3xgn+wpILAEWkmy+A+tTNbSZClhxjT3qz6g4L1A==
@@ -14478,15 +14480,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
 typescript@4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
+"typescript@^4.4.0 <4.5.0":
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Description
- Whitelist lint configs files in .dockerignore
- Ignore some of the newly introduced eslint rules. We need to fix these later.
- Adjust some of the package versions

### Motivation
Without whitelisting the lint configs building the Docker image failed. This was an issue caused from updating to new react-scripts. Somehow how it handles the lint has changed.

### How is this tested?
Locally on the dev machine