### PR TITLE
Fix opening hours validity fields a11y and required inputs & reorder time span inputs

### DIFF
--- a/src/components/exception-opening-hours-form/ExceptionOpeningHoursForm.tsx
+++ b/src/components/exception-opening-hours-form/ExceptionOpeningHoursForm.tsx
@@ -158,6 +158,7 @@ const ExceptionOpeningHoursForm = ({
                     onChange={onChange}
                     onBlur={onBlur}
                     openButtonAriaLabel="Valitse päivämäärä"
+                    required
                     value={value}
                   />
                 )}

--- a/src/components/opening-hours-form/OpeningHoursValidity.scss
+++ b/src/components/opening-hours-form/OpeningHoursValidity.scss
@@ -31,6 +31,7 @@
 @media screen and (min-width: $breakpoint-m) {
   .opening-hours-validity__dates {
     flex-direction: row;
+    align-items: flex-end;
   }
 }
 
@@ -53,6 +54,11 @@
 
 .opening-hours-validity__title {
   margin: 0;
+}
+
+.opening-hours-validity__title legend {
+  font-size: $fontsize-heading-xs;
+  font-weight: bold;
 }
 
 .opening-hours-validity__content {

--- a/src/components/opening-hours-form/OpeningHoursValidity.tsx
+++ b/src/components/opening-hours-form/OpeningHoursValidity.tsx
@@ -14,16 +14,16 @@ const OpeningHoursValidity = (): JSX.Element => {
 
   return (
     <div className="card opening-hours-validity">
-      <h3 className="opening-hours-validity__title">
-        Aukiolon voimassaoloaika*
-      </h3>
       <div className="opening-hours-validity__selections">
         <Controller
           control={control}
           name="fixed"
           render={({ field: { name, onChange, value } }): JSX.Element => (
             <>
-              <SelectionGroup label="">
+              <SelectionGroup
+                className="opening-hours-validity__title"
+                label="Aukiolon voimassaoloaika"
+                required>
                 <RadioButton
                   id="opening-hours-validity-recurring"
                   checked={!value}
@@ -59,6 +59,7 @@ const OpeningHoursValidity = (): JSX.Element => {
                       onBlur={startDateField.onBlur}
                       onChange={startDateField.onChange}
                       openButtonAriaLabel="Valitse alkupäivämäärä"
+                      required
                       value={startDateField.value}
                     />
                   )}
@@ -84,6 +85,7 @@ const OpeningHoursValidity = (): JSX.Element => {
                           onBlur={endDateField.onBlur}
                           onChange={endDateField.onChange}
                           openButtonAriaLabel="Valitse loppupäivämäärä"
+                          required
                           value={endDateField.value}
                         />
                       )}

--- a/src/components/time-span/TimeSpan.scss
+++ b/src/components/time-span/TimeSpan.scss
@@ -11,12 +11,12 @@
 
 @media screen and (min-width: $breakpoint-s) {
   .time-span {
-    grid-template-columns: 1fr 70px auto 1fr;
+    grid-template-columns: auto 70px 1fr 1fr;
   }
 }
 
 .remove-time-span-button {
-  grid-column: 1;
+  grid-column: 1/3;
   margin-left: -25px;
 }
 

--- a/src/components/time-span/TimeSpan.tsx
+++ b/src/components/time-span/TimeSpan.tsx
@@ -52,52 +52,8 @@ const TimeSpan = ({
       }
       role="group"
       aria-label={groupLabel}>
-      <Controller
-        defaultValue={item?.resource_state ?? ResourceState.OPEN}
-        name={`${namePrefix}.resource_state`}
-        control={control}
-        render={({ field: { name, onChange, value } }): JSX.Element => (
-          <Select<InputOption>
-            disabled={disabled}
-            id={getUiId([name])}
-            label="Aukiolon tyyppi"
-            options={sanitizedResourceStateOptions}
-            className="time-span__resource-state-select"
-            onChange={(option: InputOption): void => onChange(option.value)}
-            placeholder="Valitse"
-            required
-            value={sanitizedResourceStateOptions.find(
-              (option) => option.value === value
-            )}
-          />
-        )}
-      />
-      <Controller
-        defaultValue={item?.full_day ?? false}
-        render={({ field }): JSX.Element => (
-          <div
-            className={`time-span__full-day-checkbox-container ${
-              resourceState === ResourceState.CLOSED
-                ? 'time-span__full-day-checkbox-container--hidden'
-                : ''
-            }`}>
-            <Checkbox
-              className="time-span__full-day-checkbox"
-              disabled={disabled}
-              id={getUiId([namePrefix, 'full-day'])}
-              name={`${namePrefix}.full_day`}
-              label="24 h"
-              onChange={(e): void => {
-                field.onChange(e.target.checked);
-              }}
-              checked={field.value}
-            />
-          </div>
-        )}
-        control={control}
-        name={`${namePrefix}.full_day`}
-      />
       <div
+        aria-hidden={resourceState === ResourceState.CLOSED}
         className={`time-span__range ${
           resourceState === ResourceState.CLOSED
             ? 'time-span__range--hidden'
@@ -125,6 +81,31 @@ const TimeSpan = ({
           value={item?.end_time || ''}
         />
       </div>
+      <Controller
+        defaultValue={item?.full_day ?? false}
+        render={({ field }): JSX.Element => (
+          <div
+            className={`time-span__full-day-checkbox-container ${
+              resourceState === ResourceState.CLOSED
+                ? 'time-span__full-day-checkbox-container--hidden'
+                : ''
+            }`}>
+            <Checkbox
+              className="time-span__full-day-checkbox"
+              disabled={disabled}
+              id={getUiId([namePrefix, 'full-day'])}
+              name={`${namePrefix}.full_day`}
+              label="24 h"
+              onChange={(e): void => {
+                field.onChange(e.target.checked);
+              }}
+              checked={field.value}
+            />
+          </div>
+        )}
+        control={control}
+        name={`${namePrefix}.full_day`}
+      />
       {resourceState === ResourceState.OTHER && (
         <div className="time-span__descriptions">
           <Controller
@@ -166,6 +147,26 @@ const TimeSpan = ({
           />
         </div>
       )}
+      <Controller
+        defaultValue={item?.resource_state ?? ResourceState.OPEN}
+        name={`${namePrefix}.resource_state`}
+        control={control}
+        render={({ field: { name, onChange, value } }): JSX.Element => (
+          <Select<InputOption>
+            disabled={disabled}
+            id={getUiId([name])}
+            label="Aukiolon tyyppi"
+            options={sanitizedResourceStateOptions}
+            className="time-span__resource-state-select"
+            onChange={(option: InputOption): void => onChange(option.value)}
+            placeholder="Valitse"
+            required
+            value={sanitizedResourceStateOptions.find(
+              (option) => option.value === value
+            )}
+          />
+        )}
+      />
       <div className="remove-time-span-button">
         {onDelete && (
           <SupplementaryButton iconLeft={<IconTrash />} onClick={onDelete}>


### PR DESCRIPTION
### Description

Opening hours validity fields
- Fix accessibility for the radio inputs
- Fix required fields

Time span
- Revert back to old order of the inputs

### Motivation

#### Opening hours validity fields
The accessibility of the app is enhanced.

#### Time span
Now when a new time span row is created the focus goes to the start time immediately. We would have wanted to keep the current order but the select input is not focusable since we cannot pass a reference to that field. It is not supported in HDS.

### How is this tested?
Locally on the dev machine