### PR TITLE
Improve holiday edit create flow UX

### DIFF
--- a/src/components/exception-opening-hours-form-inputs/ExceptionOpeningHoursFormInputs.tsx
+++ b/src/components/exception-opening-hours-form-inputs/ExceptionOpeningHoursFormInputs.tsx
@@ -4,7 +4,7 @@ import { TranslatedApiChoice } from '../../common/lib/types';
 import TimeSpans from '../time-span/TimeSpans';
 import './ExceptionOpeningHoursFormInputs.scss';
 
-const ExceptionOpeningHours = ({
+const ExceptionOpeningHoursFormInputs = ({
   id,
   isOpen: isOpenInitially,
   onClose,
@@ -58,4 +58,4 @@ const ExceptionOpeningHours = ({
   );
 };
 
-export default ExceptionOpeningHours;
+export default ExceptionOpeningHoursFormInputs;

--- a/src/components/exception-opening-hours-form/ExceptionOpeningHoursForm.tsx
+++ b/src/components/exception-opening-hours-form/ExceptionOpeningHoursForm.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../common/utils/date-time/format';
 import { defaultTimeSpanGroup } from '../../constants';
 import useReturnToResourcePage from '../../hooks/useReturnToResourcePage';
-import ExceptionOpeningHours from '../exception-opening-hours-form-inputs/ExceptionOpeningHoursFormInputs';
+import ExceptionOpeningHoursFormInputs from '../exception-opening-hours-form-inputs/ExceptionOpeningHoursFormInputs';
 import toast from '../notification/Toast';
 import OpeningHoursFormActions from '../opening-hours-form/OpeningHoursFormActions';
 import OpeningHoursTitles from '../opening-hours-form/OpeningHoursTitles';
@@ -163,7 +163,7 @@ const ExceptionOpeningHoursForm = ({
                   />
                 )}
               />
-              <ExceptionOpeningHours
+              <ExceptionOpeningHoursFormInputs
                 id="exception-opening-hours-form"
                 onClose={(): void => {
                   setValue('resourceState', ResourceState.CLOSED);

--- a/src/components/opening-period-accordion/OpeningPeriodAccordion.tsx
+++ b/src/components/opening-period-accordion/OpeningPeriodAccordion.tsx
@@ -95,7 +95,7 @@ const OpeningPeriodAccordion = ({
             )}
             {onDelete && (
               <button
-                className="opening-period-delete-link button-icon"
+                className="button-icon"
                 data-test={`openingPeriodDeleteLink-${id}`}
                 type="button"
                 onClick={openModal}>

--- a/src/pages/EditHolidaysPage.scss
+++ b/src/pages/EditHolidaysPage.scss
@@ -34,9 +34,16 @@
 }
 
 .holiday-form-actions {
+  display: flex;
+  gap: $spacing-s;
   margin: $spacing-s 0 $spacing-3-xl;
 }
 
 .exception-opening-hours-time-spans + .holiday-form-actions {
   margin-top: $spacing-l;
+}
+
+.edit-holiday-button {
+  color: $color-coat-of-arms;
+  margin-top: -$spacing-xs;
 }

--- a/src/pages/EditHolidaysPage.scss
+++ b/src/pages/EditHolidaysPage.scss
@@ -8,6 +8,13 @@
   gap: $spacing-s $spacing-l;
 }
 
+.holidays-list-item {
+  align-items: flex-start;
+  display: flex;
+  gap: $spacing-l $spacing-m;
+  flex-wrap: wrap;
+}
+
 .holidays-list {
   margin: 0;
   padding: 0;
@@ -15,13 +22,6 @@
   .holidays-list-item:nth-child(even) {
     background-color: $color-silver;
   }
-}
-
-.holidays-list-item {
-  align-items: flex-start;
-  display: flex;
-  gap: $spacing-l $spacing-m;
-  flex-wrap: wrap;
 }
 
 .holiday-form-container {
@@ -58,8 +58,7 @@
 .holiday-list-header {
   background-color: $color-coat-of-arms;
   color: $color-white;
-  padding: $spacing-s;
-  padding-left: $spacing-2-xl;
+  display: flex;
 
   h3 {
     margin: 0;

--- a/src/pages/EditHolidaysPage.scss
+++ b/src/pages/EditHolidaysPage.scss
@@ -11,7 +11,7 @@
 .holidays-list-item {
   align-items: flex-start;
   display: flex;
-  gap: $spacing-l $spacing-m;
+  gap: 0 $spacing-xs;
   flex-wrap: wrap;
 }
 
@@ -29,6 +29,7 @@
   gap: $spacing-l $spacing-2-xl;
   flex: 1;
   flex-wrap: wrap;
+  padding: 0 $spacing-s;
 }
 
 .holiday-form-actions {

--- a/src/pages/EditHolidaysPage.scss
+++ b/src/pages/EditHolidaysPage.scss
@@ -45,13 +45,13 @@
   color: $color-coat-of-arms;
 }
 
-.holiday-checkbox-container {
+.holiday-column {
   flex: 0 0 25ch;
   white-space: nowrap;
 }
 
-.holiday-checkbox-container,
-.holiday-exception-opening-hours-container {
+.holiday-column,
+.holiday-exception-opening-hours-column {
   padding: $spacing-s $spacing-s;
 }
 

--- a/src/pages/EditHolidaysPage.scss
+++ b/src/pages/EditHolidaysPage.scss
@@ -9,20 +9,19 @@
 }
 
 .holidays-list {
+  margin: 0;
   padding: 0;
+
+  .holidays-list-item:nth-child(even) {
+    background-color: $color-silver;
+  }
 }
 
 .holidays-list-item {
   align-items: flex-start;
   display: flex;
   gap: $spacing-l $spacing-m;
-  margin-top: $spacing-m !important;
   flex-wrap: wrap;
-}
-
-.holiday-list-checkbox {
-  flex: 0 0 25ch;
-  white-space: nowrap;
 }
 
 .holiday-form-container {
@@ -30,7 +29,6 @@
   gap: $spacing-l $spacing-2-xl;
   flex: 1;
   flex-wrap: wrap;
-  margin-top: -1rem;
 }
 
 .holiday-form-actions {
@@ -45,5 +43,25 @@
 
 .edit-holiday-button {
   color: $color-coat-of-arms;
-  margin-top: -$spacing-xs;
+}
+
+.holiday-checkbox-container {
+  flex: 0 0 25ch;
+  white-space: nowrap;
+}
+
+.holiday-checkbox-container,
+.holiday-exception-opening-hours-container {
+  padding: $spacing-s $spacing-s;
+}
+
+.holiday-list-header {
+  background-color: $color-coat-of-arms;
+  color: $color-white;
+  padding: $spacing-s;
+  padding-left: $spacing-2-xl;
+
+  h3 {
+    margin: 0;
+  }
 }

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -188,7 +188,7 @@ const HolidayListItem = ({
 
   return (
     <li className="holidays-list-item" key={date}>
-      <div className="holiday-checkbox-container">
+      <div className="holiday-column">
         {value && value.id ? (
           <>
             <Checkbox
@@ -256,7 +256,7 @@ const HolidayListItem = ({
               </div>
             ) : (
               <>
-                <div className="holiday-exception-opening-hours-container">
+                <div className="holiday-exception-opening-hours-column">
                   <ExceptionOpeningHours
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     datePeriod={datePeriod!}
@@ -472,7 +472,7 @@ export default function EditHolidaysPage({
           pitää yhä paikkansa.
         </p>
         <div className="holiday-list-header">
-          <h3 className="holiday-checkbox-container">Juhlapyhä</h3>
+          <h3 className="holiday-column">Juhlapyhä</h3>
         </div>
         <ul className="holidays-list">
           {holidays.map((holiday) => {

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { CSSProperties, useCallback, useEffect, useState } from 'react';
 import { Checkbox, IconPenLine, LoadingSpinner } from 'hds-react';
 import { FormProvider, useForm } from 'react-hook-form';
 import {
@@ -181,7 +181,7 @@ const HolidayListItem = ({
       '--border-color-selected': 'var(--color-coat-of-arms)',
       '--border-color-selected-hover': 'var(--color-coat-of-arms-dark)',
       '--border-color-selected-focus': 'var(--color-coat-of-arms)',
-    } as any,
+    } as CSSProperties,
   };
   const { isModalOpen, openModal, closeModal } = useModal();
   const [isEditing, setIsEditing] = useState(!value);
@@ -258,6 +258,7 @@ const HolidayListItem = ({
               <>
                 <div className="holiday-exception-opening-hours-container">
                   <ExceptionOpeningHours
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     datePeriod={datePeriod!}
                     datePeriodConfig={datePeriodConfig}
                   />
@@ -471,7 +472,7 @@ export default function EditHolidaysPage({
           pitää yhä paikkansa.
         </p>
         <div className="holiday-list-header">
-          <h3>Juhlapyhä</h3>
+          <h3 className="holiday-checkbox-container">Juhlapyhä</h3>
         </div>
         <ul className="holidays-list">
           {holidays.map((holiday) => {

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -173,7 +173,6 @@ const HolidayListItem = ({
   const { name, date } = holiday;
   const commonCheckBoxProps = {
     id: date,
-    className: 'holiday-list-checkbox',
     label: `${name}   ${formatDate(date)}`,
     checked,
     style: {
@@ -189,47 +188,49 @@ const HolidayListItem = ({
 
   return (
     <li className="holidays-list-item" key={date}>
-      {value && value.id ? (
-        <>
+      <div className="holiday-checkbox-container">
+        {value && value.id ? (
+          <>
+            <Checkbox
+              {...commonCheckBoxProps}
+              disabled={willBeRemoved}
+              onChange={(): void => {
+                openModal();
+              }}
+            />
+            <ConfirmationModal
+              onConfirm={async (): Promise<void> => {
+                setWillBeRemoved(true);
+                await actions.delete(value);
+              }}
+              title="Oletko varma että haluat poistaa aukiolojakson?"
+              text={
+                <>
+                  <p>Olet poistamassa aukiolojakson</p>
+                  <p>
+                    <b>
+                      {value.name.fi}
+                      <br />
+                      {value.startDate}
+                    </b>
+                  </p>
+                </>
+              }
+              isOpen={isModalOpen}
+              onClose={closeModal}
+              confirmText="Poista"
+            />
+          </>
+        ) : (
           <Checkbox
             {...commonCheckBoxProps}
-            disabled={willBeRemoved}
             onChange={(): void => {
-              openModal();
+              setChecked(!checked);
+              setIsEditing(!checked);
             }}
           />
-          <ConfirmationModal
-            onConfirm={async (): Promise<void> => {
-              setWillBeRemoved(true);
-              await actions.delete(value);
-            }}
-            title="Oletko varma että haluat poistaa aukiolojakson?"
-            text={
-              <>
-                <p>Olet poistamassa aukiolojakson</p>
-                <p>
-                  <b>
-                    {value.name.fi}
-                    <br />
-                    {value.startDate}
-                  </b>
-                </p>
-              </>
-            }
-            isOpen={isModalOpen}
-            onClose={closeModal}
-            confirmText="Poista"
-          />
-        </>
-      ) : (
-        <Checkbox
-          {...commonCheckBoxProps}
-          onChange={(): void => {
-            setChecked(!checked);
-            setIsEditing(!checked);
-          }}
-        />
-      )}
+        )}
+      </div>
       {willBeRemoved ? (
         <>
           <LoadingSpinner small />
@@ -255,10 +256,12 @@ const HolidayListItem = ({
               </div>
             ) : (
               <>
-                <ExceptionOpeningHours
-                  datePeriod={datePeriod!}
-                  datePeriodConfig={datePeriodConfig}
-                />
+                <div className="holiday-exception-opening-hours-container">
+                  <ExceptionOpeningHours
+                    datePeriod={datePeriod!}
+                    datePeriodConfig={datePeriodConfig}
+                  />
+                </div>
                 {value && (
                   <button
                     className="edit-holiday-button button-icon"
@@ -467,6 +470,9 @@ export default function EditHolidaysPage({
           on voimassa toistaiseksi. Muista tarkistaa vuosittain, että tieto
           pitää yhä paikkansa.
         </p>
+        <div className="holiday-list-header">
+          <h3>Juhlapyhä</h3>
+        </div>
         <ul className="holidays-list">
           {holidays.map((holiday) => {
             const value: OpeningHoursFormValues | undefined = holidayValues


### PR DESCRIPTION
### Description
- Add editing holidays state
- Some visual improvements

### Motivation
We want to make it a bit more clearer when editing and holiday opening hours that when the hours are stored and when not. We do this by adding a edit state for the form. User first sees the existing opening hours for a holiday in a read mode. Same as in the resource page list. Then we add a edit button which activates the form and the user can make the changes accordingly. User can save or cancel. When she cancels the row will be go back to the read state.

When creating a new opening hours for a holiday. When user selects the holiday the form will activate right away. Im a bit concerned that there might be some confusion here but we'll see.

### How is this tested?
Locally on the dev machine