### PR TITLE
Add loading and empty state

### DIFF
--- a/src/components/main/Main.scss
+++ b/src/components/main/Main.scss
@@ -54,3 +54,9 @@
 .opacity-0 {
   opacity: 0;
 }
+
+.loading-spinner-container {
+  display: flex;
+  justify-content: center;
+  padding: $spacing-s;
+}

--- a/src/components/main/Main.scss
+++ b/src/components/main/Main.scss
@@ -58,5 +58,5 @@
 .loading-spinner-container {
   display: flex;
   justify-content: center;
-  padding: $spacing-s;
+  padding: $spacing-l;
 }

--- a/src/components/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/components/resource-opening-hours/ResourceOpeningHours.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Notification } from 'hds-react';
+import { LoadingSpinner, Notification } from 'hds-react';
 import { useHistory } from 'react-router-dom';
 import { partition } from 'lodash';
 import {
@@ -30,6 +30,7 @@ const ExceptionPeriodsList = ({
   language,
   parentId,
   resourceId,
+  isLoading,
 }: {
   datePeriodConfig?: UiDatePeriodConfig;
   datePeriods: DatePeriod[];
@@ -37,6 +38,7 @@ const ExceptionPeriodsList = ({
   language: Language;
   parentId?: number;
   resourceId: number;
+  isLoading: boolean;
 }): JSX.Element => {
   const history = useHistory();
   const holidays = getHolidays();
@@ -74,6 +76,11 @@ const ExceptionPeriodsList = ({
             resourceId={resourceId}
           />
         </li>
+        {isLoading && (
+          <div className="loading-spinner-container">
+            <LoadingSpinner loadingText="Haetaan aukiolojoja" small />
+          </div>
+        )}
         {exceptions.map((exception, i) => (
           <li key={exception.id}>
             <OpeningPeriodAccordion
@@ -125,6 +132,7 @@ const OpeningPeriodsList = ({
   notFoundLabel,
   deletePeriod,
   language,
+  isLoading,
 }: {
   id: string;
   parentId?: number;
@@ -137,6 +145,7 @@ const OpeningPeriodsList = ({
   notFoundLabel: string;
   deletePeriod: (id: number) => Promise<void>;
   language: Language;
+  isLoading: boolean;
 }): JSX.Element => {
   const openingPeriodsHeaderClassName =
     theme === PeriodsListTheme.LIGHT
@@ -171,6 +180,11 @@ const OpeningPeriodsList = ({
           Lisää aukioloaika +
         </SecondaryButton>
       </header>
+      {isLoading && (
+        <div className="loading-spinner-container">
+          <LoadingSpinner loadingText="Haetaan aukiolojoja" small />
+        </div>
+      )}
       {datePeriodConfig && (
         <ul className="opening-periods-list" data-test={id}>
           {datePeriods.length > 0 ? (
@@ -216,7 +230,9 @@ export default function ResourceOpeningHours({
   const [[defaultPeriods, exceptions], setDividedDatePeriods] = useState<
     [DatePeriod[], DatePeriod[]]
   >([[], []]);
+  const [isLoading, setLoading] = useState(false);
   const fetchDatePeriods = async (id: number): Promise<void> => {
+    const loadingTimeout = setTimeout(() => setLoading(true), 500);
     try {
       const [apiDatePeriods, uiDatePeriodOptions] = await Promise.all([
         api.getDatePeriods(id),
@@ -231,6 +247,8 @@ export default function ResourceOpeningHours({
     } catch (e) {
       setError(e as Error);
     }
+    clearTimeout(loadingTimeout);
+    setLoading(false);
   };
 
   useEffect(() => {
@@ -269,6 +287,7 @@ export default function ResourceOpeningHours({
         notFoundLabel="Ei aukiolojaksoja."
         deletePeriod={deletePeriod}
         language={language}
+        isLoading={isLoading}
       />
       <ExceptionPeriodsList
         datePeriodConfig={datePeriodConfig}
@@ -277,6 +296,7 @@ export default function ResourceOpeningHours({
         language={language}
         parentId={parentId}
         resourceId={resourceId}
+        isLoading={isLoading}
       />
     </>
   );

--- a/src/components/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/components/resource-opening-hours/ResourceOpeningHours.tsx
@@ -284,7 +284,7 @@ export default function ResourceOpeningHours({
         datePeriods={defaultPeriods}
         datePeriodConfig={datePeriodConfig}
         theme={PeriodsListTheme.DEFAULT}
-        notFoundLabel="Ei aukiolojaksoja."
+        notFoundLabel="Ei määriteltyjä aukioloaikoja. Aloita painamalla “Lisää aukioloaika” -painiketta."
         deletePeriod={deletePeriod}
         language={language}
         isLoading={isLoading}

--- a/src/components/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/components/resource-opening-hours/ResourceOpeningHours.tsx
@@ -232,7 +232,7 @@ export default function ResourceOpeningHours({
   >([[], []]);
   const [isLoading, setLoading] = useState(false);
   const fetchDatePeriods = async (id: number): Promise<void> => {
-    const loadingTimeout = setTimeout(() => setLoading(true), 500);
+    setLoading(true);
     try {
       const [apiDatePeriods, uiDatePeriodOptions] = await Promise.all([
         api.getDatePeriods(id),
@@ -247,7 +247,6 @@ export default function ResourceOpeningHours({
     } catch (e) {
       setError(e as Error);
     }
-    clearTimeout(loadingTimeout);
     setLoading(false);
   };
 

--- a/src/components/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/components/resource-opening-hours/ResourceOpeningHours.tsx
@@ -67,19 +67,20 @@ const ExceptionPeriodsList = ({
         </PrimaryButton>
       </header>
       <ul className="opening-periods-list">
-        <li>
-          <HolidaysTable
-            datePeriodConfig={datePeriodConfig}
-            datePeriods={holidayDatePeriods}
-            holidays={holidays}
-            parentId={parentId}
-            resourceId={resourceId}
-          />
-        </li>
-        {isLoading && (
+        {isLoading && exceptions.length === 0 ? (
           <div className="loading-spinner-container">
             <LoadingSpinner loadingText="Haetaan aukiolojoja" small />
           </div>
+        ) : (
+          <li>
+            <HolidaysTable
+              datePeriodConfig={datePeriodConfig}
+              datePeriods={holidayDatePeriods}
+              holidays={holidays}
+              parentId={parentId}
+              resourceId={resourceId}
+            />
+          </li>
         )}
         {exceptions.map((exception, i) => (
           <li key={exception.id}>
@@ -180,7 +181,7 @@ const OpeningPeriodsList = ({
           Lisää aukioloaika +
         </SecondaryButton>
       </header>
-      {isLoading && (
+      {isLoading && datePeriods.length === 0 && (
         <div className="loading-spinner-container">
           <LoadingSpinner loadingText="Haetaan aukiolojoja" small />
         </div>


### PR DESCRIPTION
### Description
- Add loading state with spinners to period tables
- Add empty states

### Motivation
Now the user is notified that data is being loaded and also knows now that the resource does not have any opening hours yet added.

### How is this tested?
Locally on dev machine
Unit tests
e2e tests