### PR TITLE
Use session storage for mass update

### DIFF
--- a/src/common/utils/storage/sessionStorage.ts
+++ b/src/common/utils/storage/sessionStorage.ts
@@ -1,0 +1,35 @@
+const storeItem = <T>({
+  key,
+  value,
+}: {
+  key: string;
+  value: T;
+}): T | undefined => {
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(value));
+    return value;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error);
+    return undefined;
+  }
+};
+
+const getItem = <T>(key: string): T | undefined => {
+  try {
+    const item = window.sessionStorage.getItem(key);
+    return item ? JSON.parse(item) : undefined;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error);
+    return undefined;
+  }
+};
+
+const removeItem = (key: string): void => window.sessionStorage.removeItem(key);
+
+export default {
+  storeItem,
+  getItem,
+  removeItem,
+};

--- a/src/pages/ResourcePage.tsx
+++ b/src/pages/ResourcePage.tsx
@@ -3,7 +3,7 @@ import { Accordion, Notification } from 'hds-react';
 import { useAppContext } from '../App-context';
 import api from '../common/utils/api/api';
 import { Language, Resource } from '../common/lib/types';
-import storage from '../common/utils/storage/storage';
+import sessionStorage from '../common/utils/storage/sessionStorage';
 import Collapse from '../components/collapse/Collapse';
 import { displayLangVersionNotFound } from '../components/language-select/LanguageSelect';
 import { Link } from '../components/link/Link';
@@ -76,19 +76,19 @@ export default function ResourcePage({
         const targetResources = targetResourcesString.split(',');
         const newData = { mainResourceId, mainResourceName, targetResources };
         setTargetResourceData(newData);
-        storage.storeItem<TargetResourcesProps>({
+        sessionStorage.storeItem<TargetResourcesProps>({
           key: targetResourcesStorageKey,
           value: newData,
         });
       } else {
-        const oldData = storage.getItem<TargetResourcesProps>(
+        const oldData = sessionStorage.getItem<TargetResourcesProps>(
           targetResourcesStorageKey
         );
         if (oldData) {
           if (oldData.mainResourceId === resource?.id) {
             setTargetResourceData(oldData);
           } else {
-            storage.removeItem(targetResourcesStorageKey);
+            sessionStorage.removeItem(targetResourcesStorageKey);
           }
         }
       }


### PR DESCRIPTION
### Description
Use session storage for storing target resources instead of local storage

### Motivation
When working on mass update and after that coming back to the same resource the targets resources would be rehydrated from the local storage thus user ending up in a confusing situation when she sees that she's still in a mass update mode.

By using the session storage we make sure that the session state is cleaned up.

### How is this tested?
- Locally on dev machine
- e2e tests