### PR TITLE
Fix handling time span groups and rules

### DIFF
--- a/src/common/helpers/opening-hours-helpers.test.ts
+++ b/src/common/helpers/opening-hours-helpers.test.ts
@@ -1,20 +1,20 @@
 /// <reference types="jest" />
 
-import { DatePeriod, ResourceState } from '../lib/types';
+import { DatePeriod, OpeningHours, ResourceState } from '../lib/types';
 import {
   apiDatePeriodToDatePeriod,
   datePeriodToApiDatePeriod,
+  datePeriodToRules,
   getActiveDatePeriod,
   isHoliday,
 } from './opening-hours-helpers';
 
-const openingHours = [
+const openingHours: OpeningHours[] = [
   {
     weekdays: [1, 2, 3, 4, 5],
     timeSpanGroups: [
       {
-        id: 1,
-        rule: 'week_every' as const,
+        rule: { id: undefined, group: 1, type: 'week_every' },
         timeSpans: [
           {
             id: 1,
@@ -40,8 +40,7 @@ const openingHours = [
     weekdays: [6],
     timeSpanGroups: [
       {
-        id: 2,
-        rule: 'week_even' as const,
+        rule: { id: 2, group: 2, type: 'week_even' },
         timeSpans: [
           {
             id: 3,
@@ -62,8 +61,7 @@ const openingHours = [
         ],
       },
       {
-        id: 3,
-        rule: 'week_odd' as const,
+        rule: { id: 3, group: 3, type: 'week_odd' },
         timeSpans: [
           {
             id: 5,
@@ -81,8 +79,7 @@ const openingHours = [
     weekdays: [7],
     timeSpanGroups: [
       {
-        id: 1,
-        rule: 'week_every' as const,
+        rule: { id: undefined, group: 1, type: 'week_every' },
         timeSpans: [
           {
             id: 6,
@@ -99,7 +96,7 @@ const openingHours = [
 ];
 
 const apiDatePeriod = {
-  id: undefined,
+  id: 1,
   end_date: '2022-12-31',
   name: { en: null, fi: 'Normaali aukiolo', sv: null },
   description: { en: null, fi: null, sv: null },
@@ -109,10 +106,12 @@ const apiDatePeriod = {
   time_span_groups: [
     {
       id: 1,
+      period: 1,
       rules: [],
       time_spans: [
         {
           id: 1,
+          group: 1,
           end_time: '16:00',
           full_day: false,
           resource_state: ResourceState.OPEN,
@@ -123,6 +122,7 @@ const apiDatePeriod = {
         },
         {
           id: 2,
+          group: 1,
           end_time: '17:00',
           full_day: false,
           resource_state: ResourceState.SELF_SERVICE,
@@ -133,6 +133,7 @@ const apiDatePeriod = {
         },
         {
           id: 6,
+          group: 1,
           end_time: null,
           full_day: false,
           resource_state: ResourceState.OPEN,
@@ -145,8 +146,11 @@ const apiDatePeriod = {
     },
     {
       id: 2,
+      period: 1,
       rules: [
         {
+          id: 2,
+          group: 2,
           context: 'year',
           subject: 'week',
           frequency_modifier: 'even',
@@ -156,6 +160,7 @@ const apiDatePeriod = {
       time_spans: [
         {
           id: 3,
+          group: 2,
           end_time: '16:00',
           full_day: false,
           resource_state: ResourceState.OPEN,
@@ -166,6 +171,7 @@ const apiDatePeriod = {
         },
         {
           id: 4,
+          group: 2,
           end_time_on_next_day: false,
           end_time: null,
           full_day: false,
@@ -178,8 +184,11 @@ const apiDatePeriod = {
     },
     {
       id: 3,
+      period: 1,
       rules: [
         {
+          id: 3,
+          group: 3,
           context: 'year',
           subject: 'week',
           frequency_modifier: 'odd',
@@ -189,6 +198,7 @@ const apiDatePeriod = {
       time_spans: [
         {
           id: 5,
+          group: 3,
           end_time: '16:00',
           full_day: false,
           resource_state: ResourceState.OPEN,
@@ -203,6 +213,7 @@ const apiDatePeriod = {
 };
 
 const datePeriod: DatePeriod = {
+  id: 1,
   name: { en: null, fi: 'Normaali aukiolo', sv: null },
   endDate: '31.12.2022',
   fixed: true,
@@ -212,7 +223,7 @@ const datePeriod: DatePeriod = {
       weekdays: [1, 2, 3, 4, 5],
       timeSpanGroups: [
         {
-          rule: 'week_every',
+          rule: { id: undefined, group: 1, type: 'week_every' },
           timeSpans: [
             {
               description: { en: null, fi: null, sv: null },
@@ -236,7 +247,7 @@ const datePeriod: DatePeriod = {
       weekdays: [6],
       timeSpanGroups: [
         {
-          rule: 'week_even',
+          rule: { id: 1, group: 2, type: 'week_even' },
           timeSpans: [
             {
               description: { en: null, fi: null, sv: null },
@@ -255,7 +266,7 @@ const datePeriod: DatePeriod = {
           ],
         },
         {
-          rule: 'week_odd',
+          rule: { id: 1, group: 3, type: 'week_odd' },
           timeSpans: [
             {
               description: { en: null, fi: null, sv: null },
@@ -272,7 +283,11 @@ const datePeriod: DatePeriod = {
       weekdays: [7],
       timeSpanGroups: [
         {
-          rule: 'week_every',
+          rule: {
+            id: undefined,
+            group: 1,
+            type: 'week_every',
+          },
           timeSpans: [
             {
               description: { en: null, fi: null, sv: null },
@@ -298,6 +313,7 @@ describe('opening-hours-helpers', () => {
           fixed: true,
           name: { fi: 'Normaali aukiolo', sv: null, en: null },
           openingHours,
+          id: 1,
           startDate: '06.06.2022',
         })
       ).toEqual(apiDatePeriod);
@@ -312,7 +328,7 @@ describe('opening-hours-helpers', () => {
         name: { fi: 'Normaali aukiolo', sv: null, en: null },
         openingHours,
         startDate: '06.06.2022',
-        id: undefined,
+        id: 1,
         override: false,
         resourceState: undefined,
       });
@@ -332,7 +348,7 @@ describe('opening-hours-helpers', () => {
               weekdays: [1, 2, 3, 4, 5],
               timeSpanGroups: [
                 {
-                  rule: 'week_every',
+                  rule: { type: 'week_every' },
                   timeSpans: [
                     {
                       id: 890209,
@@ -350,7 +366,7 @@ describe('opening-hours-helpers', () => {
               weekdays: [6, 7],
               timeSpanGroups: [
                 {
-                  rule: 'week_every',
+                  rule: { type: 'week_every' },
                   timeSpans: [
                     {
                       id: 890210,
@@ -379,7 +395,7 @@ describe('opening-hours-helpers', () => {
               weekdays: [1, 2, 3, 4, 5],
               timeSpanGroups: [
                 {
-                  rule: 'week_every',
+                  rule: { type: 'week_every' },
                   timeSpans: [
                     {
                       id: 890207,
@@ -397,7 +413,7 @@ describe('opening-hours-helpers', () => {
               weekdays: [6, 7],
               timeSpanGroups: [
                 {
-                  rule: 'week_every',
+                  rule: { type: 'week_every' },
                   timeSpans: [
                     {
                       id: 890208,
@@ -426,7 +442,7 @@ describe('opening-hours-helpers', () => {
               weekdays: [1, 2, 3, 4, 5],
               timeSpanGroups: [
                 {
-                  rule: 'week_every',
+                  rule: { type: 'week_every' },
                   timeSpans: [
                     {
                       id: 889998,
@@ -444,7 +460,7 @@ describe('opening-hours-helpers', () => {
               weekdays: [6, 7],
               timeSpanGroups: [
                 {
-                  rule: 'week_every',
+                  rule: { type: 'week_every' },
                   timeSpans: [
                     {
                       id: 889999,
@@ -473,7 +489,7 @@ describe('opening-hours-helpers', () => {
               weekdays: [1, 2, 3, 4, 5],
               timeSpanGroups: [
                 {
-                  rule: 'week_every',
+                  rule: { type: 'week_every' },
                   timeSpans: [
                     {
                       id: 889630,
@@ -491,7 +507,7 @@ describe('opening-hours-helpers', () => {
               weekdays: [6, 7],
               timeSpanGroups: [
                 {
-                  rule: 'week_every',
+                  rule: { type: 'week_every' },
                   timeSpans: [
                     {
                       id: 889631,
@@ -573,6 +589,30 @@ describe('opening-hours-helpers', () => {
           holidays
         )
       ).toBe(false);
+    });
+  });
+
+  describe('datePeriodToRules', () => {
+    it('should return correct rules ', () => {
+      expect(datePeriodToRules(datePeriod)).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "group": 1,
+            "id": undefined,
+            "type": "week_every",
+          },
+          Object {
+            "group": 2,
+            "id": 1,
+            "type": "week_even",
+          },
+          Object {
+            "group": 3,
+            "id": 1,
+            "type": "week_odd",
+          },
+        ]
+      `);
     });
   });
 });

--- a/src/common/helpers/preview-helpers.test.ts
+++ b/src/common/helpers/preview-helpers.test.ts
@@ -7,7 +7,7 @@ describe('preview-helpers', () => {
       weekdays: [1, 2, 3, 4, 5],
       timeSpanGroups: [
         {
-          rule: 'week_every' as const,
+          rule: { id: undefined, group: 1, type: 'week_every' as const },
           timeSpans: [
             {
               description: { en: null, fi: null, sv: null },
@@ -31,7 +31,7 @@ describe('preview-helpers', () => {
       weekdays: [6],
       timeSpanGroups: [
         {
-          rule: 'week_every' as const,
+          rule: { id: undefined, group: 1, type: 'week_every' as const },
           timeSpans: [
             {
               description: { en: null, fi: null, sv: null },
@@ -55,7 +55,7 @@ describe('preview-helpers', () => {
       weekdays: [7],
       timeSpanGroups: [
         {
-          rule: 'week_every' as const,
+          rule: { id: undefined, group: 1, type: 'week_every' as const },
           timeSpans: [
             {
               description: { en: null, fi: null, sv: null },
@@ -156,7 +156,11 @@ describe('preview-helpers', () => {
               ],
             },
           ],
-          "rule": "week_every",
+          "rule": Object {
+            "group": 1,
+            "id": undefined,
+            "type": "week_every",
+          },
         },
       ]
     `);

--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -234,7 +234,6 @@ export type TimeSpan = {
 };
 
 export type TimeSpanGroup = {
-  id?: number;
   rule: Rule;
   timeSpans: TimeSpan[];
 };
@@ -265,7 +264,13 @@ export type PreviewRow = {
   openingHours: PreviewOpeningHours[];
 };
 
-export type Rule = 'week_every' | 'week_odd' | 'week_even';
+export type RuleType = 'week_every' | 'week_odd' | 'week_even';
+
+export type Rule = {
+  id?: number;
+  group?: number;
+  type: RuleType;
+};
 
 export type Choice<T> = {
   value: T;

--- a/src/components/opening-hours-form/OpeningHoursForm.tsx
+++ b/src/components/opening-hours-form/OpeningHoursForm.tsx
@@ -9,6 +9,8 @@ import {
   ResourceState,
   UiDatePeriodConfig,
   DatePeriod,
+  Rule,
+  OpeningHours,
 } from '../../common/lib/types';
 import { SupplementaryButton } from '../button/Button';
 import OpeningHoursFormPreview from '../opening-hours-form-preview/OpeningHoursFormPreview';
@@ -17,6 +19,7 @@ import {
   apiDatePeriodToDatePeriod,
   byWeekdays,
   datePeriodToApiDatePeriod,
+  datePeriodToRules,
 } from '../../common/helpers/opening-hours-helpers';
 import toast from '../notification/Toast';
 import OpeningHoursWeekdays from '../opening-hours-weekdays/OpeningHoursWeekdays';
@@ -93,6 +96,7 @@ const OpeningHoursForm = ({
   const {
     resourceState: { options: resourceStates = [] },
   } = datePeriodConfig;
+  const rules = datePeriodToRules(defaultValues);
 
   const returnToResourcePage = useReturnToResourcePage();
   const onSubmit = (values: DatePeriod): void => {
@@ -236,6 +240,7 @@ const OpeningHoursForm = ({
                       i={i}
                       item={field}
                       resourceStates={resourceStates}
+                      rules={rules}
                       onDayChange={toggleWeekday(i)}
                     />
                   ))}

--- a/src/components/opening-hours-preview/OpeningHoursPreview.tsx
+++ b/src/components/opening-hours-preview/OpeningHoursPreview.tsx
@@ -10,7 +10,7 @@ import {
   TimeSpan as TTimespan,
 } from '../../common/lib/types';
 import { createWeekdaysStringFromIndices } from '../../common/utils/date-time/format';
-import { uiFrequencyRules } from '../../constants';
+import { uiRuleLabels } from '../../constants';
 import './OpeningHoursPreview.scss';
 
 const TimeSpanDescription = ({
@@ -128,13 +128,9 @@ const OpeningHoursPreview = ({
           <table
             key={`preview-row-${previewRowIdx}`}
             className="opening-hours-preview-table">
-            {previewRow.rule === 'week_every' ? null : (
+            {previewRow.rule.type === 'week_every' ? null : (
               <caption className="opening-hours-preview-table__caption">
-                {
-                  uiFrequencyRules.find(
-                    (rule) => rule.value === previewRow.rule
-                  )?.label[language]
-                }
+                {uiRuleLabels[previewRow.rule.type][language]}
               </caption>
             )}
             <thead className="opening-hours-preview-table__header hiddenFromScreen">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,32 +1,26 @@
 import {
-  LanguageStrings,
   TimeSpan,
   ResourceState,
+  RuleType,
+  Language,
   Rule,
 } from './common/lib/types';
 
-export const uiFrequencyRules: { label: LanguageStrings; value: Rule }[] = [
-  {
-    value: 'week_every',
-    label: { fi: 'Joka viikko', sv: 'Joka viikko', en: 'Joka viikko' },
+export const uiRuleLabels: {
+  [key in RuleType]: { [x in Language]: string };
+} = {
+  week_every: { fi: 'Joka viikko', sv: 'Joka viikko', en: 'Joka viikko' },
+  week_even: {
+    fi: 'Parilliset viikot',
+    sv: 'Parilliset viikot',
+    en: 'Parilliset viikot',
   },
-  {
-    value: 'week_even',
-    label: {
-      fi: 'Parilliset viikot',
-      sv: 'Parilliset viikot',
-      en: 'Parilliset viikot',
-    },
+  week_odd: {
+    fi: 'Parittomat viikot',
+    sv: 'Parittomat viikot',
+    en: 'Parittomat viikot',
   },
-  {
-    value: 'week_odd',
-    label: {
-      fi: 'Parittomat viikot',
-      sv: 'Parittomat viikot',
-      en: 'Parittomat viikot',
-    },
-  },
-];
+};
 
 export const defaultTimeSpan: TimeSpan = {
   description: { fi: null, sv: null, en: null },
@@ -37,6 +31,12 @@ export const defaultTimeSpan: TimeSpan = {
 };
 
 export const defaultTimeSpanGroup = {
-  rule: 'week_every' as const,
+  rule: { id: undefined, type: 'week_every' as const },
   timeSpans: [defaultTimeSpan],
+};
+
+export const defaultRule: Rule = {
+  id: undefined,
+  group: undefined,
+  type: 'week_every' as const,
 };

--- a/test/fixtures/date-period.ts
+++ b/test/fixtures/date-period.ts
@@ -11,7 +11,7 @@ export const datePeriod: DatePeriod = {
       weekdays: [1, 3],
       timeSpanGroups: [
         {
-          rule: 'week_every',
+          rule: { id: undefined, group: 1, type: 'week_every' },
           timeSpans: [
             {
               id: 9054,
@@ -29,7 +29,7 @@ export const datePeriod: DatePeriod = {
       weekdays: [2, 4],
       timeSpanGroups: [
         {
-          rule: 'week_every',
+          rule: { id: undefined, group: 1, type: 'week_every' },
           timeSpans: [
             {
               id: 14667,
@@ -47,7 +47,7 @@ export const datePeriod: DatePeriod = {
       weekdays: [6, 7],
       timeSpanGroups: [
         {
-          rule: 'week_every',
+          rule: { id: undefined, group: 1, type: 'week_every' },
           timeSpans: [
             {
               id: 14691,


### PR DESCRIPTION
### Description
- Fix mapping data from UI to API.

### Motivation
We were lacking mapping the correct rule ids and time span groups when creating opening hours with some variable time spans e.g. `week_odd` and `week_even`. 

This occurred so that if you updated an opening hours with variable time spans one of the time span groups got lost. We did not persist the rule id for the rule selections or the keeping the rules and time span groups together thus making the UI behave oddly.

Now the rule select contains both the rule id and time span group id tying these both together tightly making sure that any existing time span group with rules are used when updating the opening hour variability.

### How is this tested?
- Unit tests
- e2e tests
- Locally on dev machine