### PR TITLE
Add support for adding time spans without opening hours

### DIFF
--- a/cypress/integration/NormalOpeningHours.ts
+++ b/cypress/integration/NormalOpeningHours.ts
@@ -109,4 +109,75 @@ describe('User adds a new opening period', () => {
       timeout: 10000,
     }).should('be.visible');
   });
+
+  it('Users successfully adds a weekday with no opening hours', () => {
+    // Go to add new openings hours
+    cy.get('[data-test=add-new-opening-period-button]').click();
+
+    // Fill in opening hours
+
+    // Start filling the form, first is opening period title in finnish
+    cy.get('[data-test=opening-period-title-fi').type(
+      `e2e-test Testijakson otsikko ${new Date().toJSON()}`
+    );
+
+    // ...then in swedish
+    cy.get('[data-test=opening-period-title-sv').type(
+      `e2e-test test periods rubrik ${new Date().toJSON()}`
+    );
+    // ...then in english
+    cy.get('[data-test=opening-period-title-en').type(
+      `e2e-test test period's title ${new Date().toJSON()}`
+    );
+
+    // Then select the begin and end date for the period. For the test we wish to select the summer dates
+    cy.get('[data-test=opening-hours-validity-fixed-option').click({
+      force: true,
+    });
+    cy.get('[data-test=opening-period-begin-date]').click();
+    cy.get('button[aria-label="Valitse alkupäivämäärä"]').click();
+    cy.get('select[aria-label="Kuukausi"]').first().select('5');
+    cy.get(`[role="dialog"] button[data-date$="01"]`)
+      .filter(':visible')
+      .click({ force: true });
+    cy.get('[data-test="opening-period-end-date"]').click();
+    cy.get('button[aria-label="Valitse loppupäivämäärä"]')
+      .filter(':visible')
+      .click();
+    cy.get('select[aria-label="Kuukausi"]').last().select('6');
+    cy.get(`[role="dialog"] button[data-date$="31"]`)
+      .filter(':visible')
+      .click({ force: true });
+
+    cy.setHdsTimeInputTime({
+      id: 'openingHours-0-timeSpanGroups-0-timeSpans-0-start-time',
+      hours: '08',
+      minutes: '00',
+    });
+    cy.setHdsTimeInputTime({
+      id: 'openingHours-0-timeSpanGroups-0-timeSpans-0-end-time',
+      hours: '16',
+      minutes: '00',
+    });
+
+    // Separate Wednesday as it's own day
+    cy.get('[data-test=openingHours-0-weekdays-3').click();
+
+    // Has Ei aukioloa as default
+    cy.get(
+      '#openingHours-1-timeSpanGroups-0-timeSpans-0-resource_state-toggle-button'
+    ).should('have.text', 'Ei aukioloa');
+
+    // Cannot add more time spans to the weekday
+    cy.get(
+      '[data-testopeningHours-1-timeSpanGroups-0-timeSpans-add-time-span-button]'
+    ).should('not.be', 'visible');
+
+    // Save opening hours
+    cy.get('[data-test=submit-opening-hours-button]').click();
+
+    cy.get('[data-testid=opening-period-form-success]', {
+      timeout: 10000,
+    }).should('be.visible');
+  });
 });

--- a/src/common/helpers/opening-hours-helpers.ts
+++ b/src/common/helpers/opening-hours-helpers.ts
@@ -324,9 +324,11 @@ export const isClosed = (resourceState: ResourceState): boolean =>
   [
     ResourceState.CLOSED,
     ResourceState.MAINTENANCE,
-    ResourceState.UNDEFINED,
     ResourceState.NOT_IN_USE,
   ].includes(resourceState);
+
+export const isDescriptionAllowed = (resourceState: ResourceState): boolean =>
+  resourceState !== ResourceState.UNDEFINED;
 
 const ruleTypeOrder: RuleType[] = ['week_every', 'week_even', 'week_odd'];
 

--- a/src/components/navigation/HaukiNavigation.tsx
+++ b/src/components/navigation/HaukiNavigation.tsx
@@ -82,7 +82,7 @@ export default function HaukiNavigation(): JSX.Element {
           href="https://kaupunkialustana.hel.fi/aukiolosovellus-ohje/"
           target="_blank"
           rel="noreferrer">
-          <IconQuestionCircle /> Ohje
+          <IconQuestionCircle aria-hidden="true" /> Ohje
         </a>
         {isAuthenticated && (
           <>

--- a/src/components/opening-hours-form/OpeningHoursForm.tsx
+++ b/src/components/opening-hours-form/OpeningHoursForm.tsx
@@ -150,7 +150,17 @@ const OpeningHoursForm = ({
     const newIdx = currIndex + 1;
     const values = {
       weekdays: [day],
-      timeSpanGroups: [defaultTimeSpanGroup],
+      timeSpanGroups: [
+        {
+          ...defaultTimeSpanGroup,
+          timeSpans: [
+            {
+              ...defaultTimeSpan,
+              resource_state: ResourceState.UNDEFINED,
+            },
+          ],
+        },
+      ],
     };
     insert(newIdx, values, { shouldFocus: false });
     // FIXME: For some reason the normal array won't get added in the insert

--- a/src/components/opening-hours-preview/OpeningHoursPreview.tsx
+++ b/src/components/opening-hours-preview/OpeningHoursPreview.tsx
@@ -26,7 +26,12 @@ const TimeSpanDescription = ({
     return <>Tuntematon</>;
   }
 
-  if (timeSpan.resource_state === ResourceState.OPEN) {
+  if (
+    timeSpan.resource_state &&
+    [ResourceState.OPEN, ResourceState.UNDEFINED].includes(
+      timeSpan.resource_state
+    )
+  ) {
     return null;
   }
 

--- a/src/components/opening-period-accordion/OpeningPeriodAccordion.tsx
+++ b/src/components/opening-period-accordion/OpeningPeriodAccordion.tsx
@@ -113,7 +113,7 @@ const OpeningPeriodAccordion = ({
             data-test={`openingPeriodAccordionButton${id ? `-${id}` : ''}`}
             type="button"
             {...buttonProps}>
-            <AccordionIcon />
+            <AccordionIcon aria-hidden="true" />
             <span className="hiddenFromScreen">{`Näytä aukioloajat jaksosta ${
               periodName || 'nimetön'
             } aukiolojakso`}</span>

--- a/src/components/time-span/TimeSpan.tsx
+++ b/src/components/time-span/TimeSpan.tsx
@@ -38,12 +38,19 @@ const TimeSpan = ({
   const { control, register, watch } = useFormContext<DatePeriod>();
   const fullDay = watch(`${namePrefix}.full_day`);
   const resourceState = watch(`${namePrefix}.resource_state`);
-  const resourceStateOptions = resourceStates.map(choiceToOption(language));
-  const sanitizedResourceStateOptions: InputOption[] = resourceStateOptions.filter(
-    ({ value }) => value !== 'undefined'
-  );
+  const sanitizedResourceStateOptions = resourceStates
+    .filter((elem) => {
+      if (i > 0 && elem.value === ResourceState.UNDEFINED) {
+        return false;
+      }
+      return true;
+    })
+    .map(choiceToOption(language));
 
-  const showTimeSpans = resourceState !== ResourceState.CLOSED || i !== 0;
+  const showTimeSpans =
+    (resourceState !== ResourceState.UNDEFINED &&
+      resourceState !== ResourceState.CLOSED) ||
+    i !== 0;
 
   return (
     <div
@@ -117,48 +124,52 @@ const TimeSpan = ({
           />
         )}
       />
-      <div className="time-span__descriptions">
-        <Controller
-          defaultValue={item?.description.fi ?? ''}
-          name={`${namePrefix}.description.fi`}
-          render={({ field: { name, onChange, value } }): JSX.Element => (
-            <TextInput
-              id={getUiId([name])}
-              label="Kuvaus suomeksi"
-              onChange={onChange}
-              placeholder="Esim. seniorit"
-              value={value || ''}
+      {resourceState !== ResourceState.UNDEFINED && (
+        <>
+          <div className="time-span__descriptions">
+            <Controller
+              defaultValue={item?.description.fi ?? ''}
+              name={`${namePrefix}.description.fi`}
+              render={({ field: { name, onChange, value } }): JSX.Element => (
+                <TextInput
+                  id={getUiId([name])}
+                  label="Kuvaus suomeksi"
+                  onChange={onChange}
+                  placeholder="Esim. seniorit"
+                  value={value || ''}
+                />
+              )}
             />
-          )}
-        />
-        <Controller
-          defaultValue={item?.description.sv ?? ''}
-          name={`${namePrefix}.description.sv`}
-          render={({ field: { name, onChange, value } }): JSX.Element => (
-            <TextInput
-              id={getUiId([name])}
-              label="Kuvaus ruotsiksi"
-              onChange={onChange}
-              placeholder="T.ex. seniorer"
-              value={value || ''}
+            <Controller
+              defaultValue={item?.description.sv ?? ''}
+              name={`${namePrefix}.description.sv`}
+              render={({ field: { name, onChange, value } }): JSX.Element => (
+                <TextInput
+                  id={getUiId([name])}
+                  label="Kuvaus ruotsiksi"
+                  onChange={onChange}
+                  placeholder="T.ex. seniorer"
+                  value={value || ''}
+                />
+              )}
             />
-          )}
-        />
-        <Controller
-          defaultValue={item?.description.en ?? ''}
-          name={`${namePrefix}.description.en`}
-          render={({ field: { name, onChange, value } }): JSX.Element => (
-            <TextInput
-              id={getUiId([name])}
-              label="Kuvaus englanniksi"
+            <Controller
+              defaultValue={item?.description.en ?? ''}
               name={`${namePrefix}.description.en`}
-              onChange={onChange}
-              placeholder="E.g. seniors"
-              value={value || ''}
+              render={({ field: { name, onChange, value } }): JSX.Element => (
+                <TextInput
+                  id={getUiId([name])}
+                  label="Kuvaus englanniksi"
+                  name={`${namePrefix}.description.en`}
+                  onChange={onChange}
+                  placeholder="E.g. seniors"
+                  value={value || ''}
+                />
+              )}
             />
-          )}
-        />
-      </div>
+          </div>
+        </>
+      )}
       <div className="remove-time-span-button">
         {onDelete && (
           <SupplementaryButton iconLeft={<IconTrash />} onClick={onDelete}>

--- a/src/components/time-span/TimeSpans.tsx
+++ b/src/components/time-span/TimeSpans.tsx
@@ -1,9 +1,11 @@
 import { IconPlusCircle } from 'hds-react';
 import React, { useEffect, useRef } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
+import { isDescriptionAllowed } from '../../common/helpers/opening-hours-helpers';
 import {
   DatePeriod,
   ResourceState,
+  TimeSpan as TTimeSpan,
   TranslatedApiChoice,
 } from '../../common/lib/types';
 import { getUiId } from '../../common/utils/form/form';
@@ -11,6 +13,28 @@ import { defaultTimeSpan } from '../../constants';
 import { SupplementaryButton } from '../button/Button';
 import TimeSpan from './TimeSpan';
 import './TimeSpans.scss';
+
+const shouldHideTimeSpan = (resourceState: ResourceState): boolean =>
+  [ResourceState.CLOSED, ResourceState.UNDEFINED].includes(resourceState);
+
+const resetTimeSpan = (timeSpan: TTimeSpan): TTimeSpan => {
+  let newTimeSpan = {
+    ...defaultTimeSpan,
+    resource_state: timeSpan.resource_state,
+  };
+
+  if (
+    timeSpan.resource_state &&
+    isDescriptionAllowed(timeSpan.resource_state)
+  ) {
+    newTimeSpan = {
+      ...newTimeSpan,
+      description: timeSpan.description,
+    };
+  }
+
+  return newTimeSpan;
+};
 
 const TimeSpans = ({
   openingHoursIdx,
@@ -28,20 +52,23 @@ const TimeSpans = ({
     name: namePrefix,
   });
   const ref = useRef<HTMLButtonElement>(null);
+
+  // Without this for some reason the key inference breaks :(
+  const first = 0 as number;
+  const firstTimeSpanKey = `${namePrefix}.${first}` as const;
   const firstTimeSpanResourceState = watch(
-    'openingHours.0.timeSpanGroups.0.timeSpans.0.resource_state'
+    `${firstTimeSpanKey}.resource_state`
   );
+  const hideAddTimeSpan =
+    !!firstTimeSpanResourceState &&
+    shouldHideTimeSpan(firstTimeSpanResourceState);
 
   useEffect(() => {
-    if (firstTimeSpanResourceState === ResourceState.CLOSED) {
-      const description = getValues(
-        'openingHours.0.timeSpanGroups.0.timeSpans.0.description'
+    if (hideAddTimeSpan) {
+      setValue(
+        firstTimeSpanKey,
+        resetTimeSpan(getValues(`${firstTimeSpanKey}`))
       );
-      setValue('openingHours.0.timeSpanGroups.0.timeSpans.0', {
-        ...defaultTimeSpan,
-        description,
-        resource_state: ResourceState.CLOSED,
-      });
 
       if (fields.length > 1) {
         fields.forEach((field, i) => {
@@ -51,7 +78,15 @@ const TimeSpans = ({
         });
       }
     }
-  }, [fields, firstTimeSpanResourceState, getValues, setValue, remove]);
+  }, [
+    fields,
+    firstTimeSpanResourceState,
+    firstTimeSpanKey,
+    hideAddTimeSpan,
+    getValues,
+    setValue,
+    remove,
+  ]);
 
   return (
     <div className="time-spans">
@@ -75,7 +110,7 @@ const TimeSpans = ({
           }
         />
       ))}
-      {firstTimeSpanResourceState !== ResourceState.CLOSED && (
+      {!hideAddTimeSpan && (
         <div>
           <SupplementaryButton
             dataTest={getUiId([namePrefix, 'add-time-span-button'])}


### PR DESCRIPTION
### Motivation & context

There is a need to define opening hours without actual time spans. At the moment the system does not allow it making users to leave start and end times empty and leaving the resource state as open. This causes issues in services using Hauki API. For the services it seems that the resource would be open even though there is no actual opening hours.

### Proposed solution

Release setting an time span with a resource state undefined meaning no opening hours for that day. This allows the user to not set any opening hours for given dates and also making sure that they still address all the weekdays.

- When user separates a weekday to it's own date set `undefined` as the default resource state.
- Allow only setting `undefined` only for the first time span in the time span group. If there are already more that one time span in the group delete the other ones
- Filter out  `undefined` state from selections other that from the first time span
- Do not show description when `undefined` is selected

### How was this tested?
- Locally on dev machine
- e2e tests