### PR TITLE
Ignore error ResizeObserver loop completed with undelivered notifications in Sentry

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,9 @@ Sentry.init({
   integrations: [new Integrations.BrowserTracing()],
   environment: window.ENV.SENTRY_ENV,
   sampleRate: window.ENV.SENTRY_ENV === 'local' ? 0.0 : 1.0, // We do not wish to trace in local env by default
+  ignoreErrors: [
+    'ResizeObserver loop completed with undelivered notifications',
+  ],
 });
 
 if (window.ENV?.USE_AXE === 'true') {


### PR DESCRIPTION
Lets ignore the error for now so that it won't pollute the error monitoring and because it seems not to cause any drastic issues to the users. 

Hypothesis is that `react-use-measure` and `juggle/resize-observer` libraries in [hds-react](https://www.npmjs.com/package/hds-react) are causing this. 