### PR TITLE
Add display holiday eves

### DIFF
--- a/src/common/helpers/opening-hours-helpers.test.ts
+++ b/src/common/helpers/opening-hours-helpers.test.ts
@@ -6,7 +6,7 @@ import {
   datePeriodToApiDatePeriod,
   datePeriodToRules,
   getActiveDatePeriod,
-  isHoliday,
+  isHolidayOrEve,
 } from './opening-hours-helpers';
 
 const openingHours: OpeningHours[] = [
@@ -541,6 +541,7 @@ describe('opening-hours-helpers', () => {
           en: "New Year's Eve",
         },
         start_date: '2022-12-31',
+        eve: false,
       },
       {
         date: '2023-01-01',
@@ -551,12 +552,13 @@ describe('opening-hours-helpers', () => {
           en: "New Year's Day",
         },
         start_date: '2022-12-31',
+        eve: false,
       },
     ];
 
     it('should return true when datePeriod is override and matches with holiday', () => {
       expect(
-        isHoliday(
+        isHolidayOrEve(
           {
             ...datePeriod,
             startDate: '31.12.2022',
@@ -575,7 +577,7 @@ describe('opening-hours-helpers', () => {
 
     it('should return false when datePeriod is override but the range does not match with holiday', () => {
       expect(
-        isHoliday(
+        isHolidayOrEve(
           {
             ...datePeriod,
             startDate: '25.12.2022',
@@ -594,7 +596,7 @@ describe('opening-hours-helpers', () => {
 
     it('should return false when datePeriod is override and name does not match with holiday', () => {
       expect(
-        isHoliday(
+        isHolidayOrEve(
           {
             ...datePeriod,
             startDate: '31.12.2022',

--- a/src/common/helpers/opening-hours-helpers.ts
+++ b/src/common/helpers/opening-hours-helpers.ts
@@ -1,8 +1,8 @@
 import differenceInMilliseconds from 'date-fns/differenceInMilliseconds';
+import { Holiday } from '../../services/holidays';
 import {
   ApiDatePeriod,
   GroupRule,
-  Holiday,
   OpeningHours,
   DatePeriod,
   TimeSpan,
@@ -303,7 +303,7 @@ export const getActiveDatePeriod = (
 
 const dayInMilliseconds = 24 * 60 * 60 * 1000;
 
-export const isHoliday = (
+export const isHolidayOrEve = (
   datePeriod: DatePeriod,
   holidays: Holiday[]
 ): boolean =>

--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -286,8 +286,3 @@ export type Choice<T> = {
   value: T;
   label: LanguageStrings;
 };
-
-export type Holiday = {
-  date: string;
-  name: LanguageStrings;
-};

--- a/src/components/holidays-table/HolidaysTable.tsx
+++ b/src/components/holidays-table/HolidaysTable.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { useAppContext } from '../../App-context';
-import { isHoliday } from '../../common/helpers/opening-hours-helpers';
+import { isHolidayOrEve } from '../../common/helpers/opening-hours-helpers';
 import {
-  Holiday,
   DatePeriod,
   UiDatePeriodConfig,
   Language,
 } from '../../common/lib/types';
 import { formatDate } from '../../common/utils/date-time/format';
+import { Holiday, isHoliday } from '../../services/holidays';
 import ExceptionOpeningHours from '../exception-opening-hours/ExceptionOpeningHours';
 import OpeningPeriodAccordion from '../opening-period-accordion/OpeningPeriodAccordion';
 import './HolidaysTable.scss';
@@ -21,7 +21,7 @@ const HolidayOpeningHours = ({
   datePeriods: DatePeriod[];
   holiday: Holiday;
 }): JSX.Element => {
-  const datePeriod = datePeriods.find((dp) => isHoliday(dp, [holiday]));
+  const datePeriod = datePeriods.find((dp) => isHolidayOrEve(dp, [holiday]));
 
   if (datePeriod) {
     return (
@@ -38,13 +38,19 @@ const HolidayOpeningHours = ({
 export const UpcomingHolidayNotification = ({
   datePeriodConfig,
   datePeriods,
-  holiday,
+  holidays,
 }: {
   datePeriodConfig?: UiDatePeriodConfig;
   datePeriods: DatePeriod[];
-  holiday: Holiday;
+  holidays: Holiday[];
 }): JSX.Element => {
   const { language = Language.FI } = useAppContext();
+  const holiday = holidays.find(isHoliday);
+
+  if (!holiday) {
+    throw new Error('Holiday not found');
+  }
+
   return (
     <div className="upcoming-holidays">
       <span>
@@ -81,7 +87,7 @@ const HolidaysTable = ({
         <UpcomingHolidayNotification
           datePeriodConfig={datePeriodConfig}
           datePeriods={datePeriods}
-          holiday={holidays[0]}
+          holidays={holidays}
         />
       }>
       <div className="holidays-container">

--- a/src/components/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/components/resource-opening-hours/ResourceOpeningHours.tsx
@@ -17,11 +17,11 @@ import {
   apiDatePeriodToDatePeriod,
   getActiveDatePeriod,
   getDatePeriodName,
-  isHoliday,
+  isHolidayOrEve,
 } from '../../common/helpers/opening-hours-helpers';
 import { getDatePeriodFormConfig } from '../../services/datePeriodFormConfig';
 import HolidaysTable from '../holidays-table/HolidaysTable';
-import { getHolidays } from '../../services/holidays';
+import { getHolidaysAndEves } from '../../services/holidays';
 import OpeningPeriodAccordion from '../opening-period-accordion/OpeningPeriodAccordion';
 import ExceptionOpeningHours from '../exception-opening-hours/ExceptionOpeningHours';
 
@@ -49,10 +49,10 @@ const ExceptionPeriodsList = ({
   holidaysTableInitiallyOpen: boolean;
 }): JSX.Element => {
   const history = useHistory();
-  const holidays = getHolidays();
+  const holidays = getHolidaysAndEves();
   const [holidayDatePeriods, exceptions] = partition(
     datePeriods,
-    (datePeriod) => isHoliday(datePeriod, holidays)
+    (datePeriod) => isHolidayOrEve(datePeriod, holidays)
   );
   const ref = useRef<HTMLButtonElement>(null);
 

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -3,7 +3,6 @@ import { Checkbox, IconPenLine, LoadingSpinner } from 'hds-react';
 import { FormProvider, useForm } from 'react-hook-form';
 import {
   ApiDatePeriod,
-  Holiday,
   Language,
   DatePeriod,
   Resource,
@@ -14,11 +13,11 @@ import {
 import {
   apiDatePeriodToDatePeriod,
   datePeriodToApiDatePeriod,
-  isHoliday,
+  isHolidayOrEve,
 } from '../common/helpers/opening-hours-helpers';
 import api from '../common/utils/api/api';
 import { getDatePeriodFormConfig } from '../services/datePeriodFormConfig';
-import { getHolidays } from '../services/holidays';
+import { getHolidaysAndEves, Holiday } from '../services/holidays';
 import {
   formatDate,
   getNumberOfTheWeekday,
@@ -309,7 +308,7 @@ export default function EditHolidaysPage({
           api.getResource(resourceId),
           getDatePeriodFormConfig(),
         ]);
-        setHolidays(getHolidays());
+        setHolidays(getHolidaysAndEves());
         setResource(apiResource);
         setDatePeriodConfig(uiDatePeriodOptions);
       } catch (e) {
@@ -328,7 +327,7 @@ export default function EditHolidaysPage({
       );
       const holidayPeriodsResult: DatePeriod[] = apiDatePeriods
         .map(apiDatePeriodToDatePeriod)
-        .filter((apiDatePeriod) => isHoliday(apiDatePeriod, holidays));
+        .filter((apiDatePeriod) => isHolidayOrEve(apiDatePeriod, holidays));
 
       setHolidayValues(holidayPeriodsResult);
     },
@@ -457,7 +456,7 @@ export default function EditHolidaysPage({
             <UpcomingHolidayNotification
               datePeriodConfig={datePeriodConfig}
               datePeriods={holidayValues}
-              holiday={holidays[0]}
+              holidays={holidays}
             />
           )}
         </div>

--- a/src/pages/ResourcePage.test.tsx
+++ b/src/pages/ResourcePage.test.tsx
@@ -132,7 +132,7 @@ describe(`<ResourcePage />`, () => {
       .spyOn(api, 'getParentResourcesByChildId')
       .mockImplementation(() => Promise.resolve([testParentResource]));
 
-    jest.spyOn(holidays, 'getHolidays').mockImplementation(() => [
+    jest.spyOn(holidays, 'getHolidaysAndEves').mockImplementation(() => [
       {
         name: {
           fi: 'Juhannusaatto',
@@ -140,6 +140,7 @@ describe(`<ResourcePage />`, () => {
           en: 'Midsummer Eve',
         },
         date: '2022-06-24',
+        eve: false,
       },
     ]);
   });


### PR DESCRIPTION
### Context and opportunity
For Christmas, Midsummer, New Year's Eve, May Day usually the day before those holidays the opening hours are somewhat different than normal.

At the moment users first add the exceptional opening hours for the holiday by using the holidays table functionality and then after that they need to go and add the eve by using the regular exceptional opening hours functionality. There is a bit of back and forth jumping between the views causing frustation.

### Intervention
For Christmas, Midsummer, New Year's Eve, May Day lets add the eves before those days.

### Outcome
It's easier to handle the holiday season as a whole.

