### PR TITLE
Fix displaying active date period

### DIFF
--- a/src/common/helpers/opening-hours-helpers.test.ts
+++ b/src/common/helpers/opening-hours-helpers.test.ts
@@ -9,7 +9,7 @@ import {
   apiDatePeriodToDatePeriod,
   datePeriodToApiDatePeriod,
   datePeriodToRules,
-  getActiveDatePeriod,
+  getActiveDatePeriods,
   alignOpeningHoursWeekdaysToDateRange,
   isHolidayOrEve,
   updateRule,
@@ -311,6 +311,237 @@ const datePeriod: DatePeriod = {
   override: false,
 };
 
+const datePeriods: DatePeriod[] = [
+  {
+    name: { fi: 'Normaaliaukiolo', sv: '', en: '' },
+    endDate: '31.12.2022',
+    fixed: true,
+    startDate: '01.01.2022',
+    openingHours: [
+      {
+        weekdays: [1, 2, 3, 4, 5],
+        timeSpanGroups: [
+          {
+            rule: { type: 'week_every' },
+            timeSpans: [
+              {
+                id: 890209,
+                description: { fi: null, sv: null, en: null },
+                end_time: null,
+                full_day: false,
+                resource_state: ResourceState.OPEN,
+                start_time: null,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        weekdays: [6, 7],
+        timeSpanGroups: [
+          {
+            rule: { type: 'week_every' },
+            timeSpans: [
+              {
+                id: 890210,
+                description: { fi: null, sv: null, en: null },
+                end_time: null,
+                full_day: false,
+                resource_state: ResourceState.CLOSED,
+                start_time: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    id: 1041529,
+    resourceState: ResourceState.UNDEFINED,
+    override: false,
+  },
+  {
+    name: { fi: 'Kesäkuun aukiolot', sv: '', en: '' },
+    endDate: '30.06.2022',
+    fixed: true,
+    startDate: '01.06.2022',
+    openingHours: [
+      {
+        weekdays: [1, 2, 3, 4, 5],
+        timeSpanGroups: [
+          {
+            rule: { type: 'week_every' },
+            timeSpans: [
+              {
+                id: 890207,
+                description: { fi: null, sv: null, en: null },
+                end_time: '15:00',
+                full_day: false,
+                resource_state: ResourceState.OPEN,
+                start_time: '10:00',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        weekdays: [6, 7],
+        timeSpanGroups: [
+          {
+            rule: { type: 'week_every' },
+            timeSpans: [
+              {
+                id: 890208,
+                description: { fi: null, sv: null, en: null },
+                end_time: null,
+                full_day: false,
+                resource_state: ResourceState.CLOSED,
+                start_time: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    id: 1039083,
+    resourceState: ResourceState.UNDEFINED,
+    override: false,
+  },
+  {
+    name: { fi: 'Juhannus', sv: '', en: '' },
+    endDate: '24.06.2022',
+    fixed: true,
+    startDate: '24.06.2022',
+    openingHours: [
+      {
+        weekdays: [5],
+        timeSpanGroups: [
+          {
+            rule: { type: 'week_every' },
+            timeSpans: [
+              {
+                id: 889998,
+                description: { fi: null, sv: null, en: null },
+                end_time: null,
+                full_day: true,
+                resource_state: ResourceState.CLOSED,
+                start_time: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    id: 1039084,
+    resourceState: ResourceState.UNDEFINED,
+    override: true,
+  },
+  {
+    name: { fi: 'Heinäkuun aukiolot', sv: '', en: '' },
+    endDate: '31.07.2022',
+    fixed: true,
+    startDate: '01.07.2022',
+    openingHours: [
+      {
+        weekdays: [1, 2, 3, 4, 5],
+        timeSpanGroups: [
+          {
+            rule: { type: 'week_every' },
+            timeSpans: [
+              {
+                id: 889630,
+                description: { fi: null, sv: null, en: null },
+                end_time: null,
+                full_day: false,
+                resource_state: ResourceState.OPEN,
+                start_time: null,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        weekdays: [6, 7],
+        timeSpanGroups: [
+          {
+            rule: { type: 'week_every' },
+            timeSpans: [
+              {
+                id: 889631,
+                description: { fi: null, sv: null, en: null },
+                end_time: null,
+                full_day: false,
+                resource_state: ResourceState.CLOSED,
+                start_time: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    id: 1041197,
+    resourceState: ResourceState.UNDEFINED,
+    override: false,
+  },
+  {
+    name: { fi: 'Remontti', sv: '', en: '' },
+    endDate: '19.05.2023',
+    fixed: true,
+    startDate: '15.05.2023',
+    openingHours: [
+      {
+        weekdays: [1, 2, 3, 4, 5, 6, 7],
+        timeSpanGroups: [
+          {
+            rule: { type: 'week_every' },
+            timeSpans: [
+              {
+                id: 889998,
+                description: { fi: null, sv: null, en: null },
+                end_time: null,
+                full_day: true,
+                resource_state: ResourceState.CLOSED,
+                start_time: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    id: 1039078,
+    resourceState: ResourceState.UNDEFINED,
+    override: true,
+  },
+  {
+    name: { fi: 'Helatorstai', sv: '', en: '' },
+    endDate: '18.05.2023',
+    fixed: true,
+    startDate: '18.05.2023',
+    openingHours: [
+      {
+        weekdays: [4],
+        timeSpanGroups: [
+          {
+            rule: { type: 'week_every' },
+            timeSpans: [
+              {
+                id: 889998,
+                description: { fi: null, sv: null, en: null },
+                end_time: null,
+                full_day: true,
+                resource_state: ResourceState.CLOSED,
+                start_time: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    id: 1039079,
+    resourceState: ResourceState.UNDEFINED,
+    override: true,
+  },
+];
+
 describe('opening-hours-helpers', () => {
   describe('openingHoursToApiDatePeriod', () => {
     it('should map to correct data', () => {
@@ -357,199 +588,30 @@ describe('opening-hours-helpers', () => {
     });
   });
 
-  describe('getActiveDatePeriod', () => {
-    expect(
-      getActiveDatePeriod('2022-06-23', [
-        {
-          name: { fi: 'Normaaliaukiolo', sv: '', en: '' },
-          endDate: '31.12.2022',
-          fixed: true,
-          startDate: '01.01.2022',
-          openingHours: [
-            {
-              weekdays: [1, 2, 3, 4, 5],
-              timeSpanGroups: [
-                {
-                  rule: { type: 'week_every' },
-                  timeSpans: [
-                    {
-                      id: 890209,
-                      description: { fi: null, sv: null, en: null },
-                      end_time: null,
-                      full_day: false,
-                      resource_state: ResourceState.OPEN,
-                      start_time: null,
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              weekdays: [6, 7],
-              timeSpanGroups: [
-                {
-                  rule: { type: 'week_every' },
-                  timeSpans: [
-                    {
-                      id: 890210,
-                      description: { fi: null, sv: null, en: null },
-                      end_time: null,
-                      full_day: false,
-                      resource_state: ResourceState.CLOSED,
-                      start_time: null,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-          id: 1041529,
-          resourceState: ResourceState.UNDEFINED,
-          override: false,
-        },
-        {
-          name: { fi: 'Kesäkuun aukiolot', sv: '', en: '' },
-          endDate: '30.06.2022',
-          fixed: true,
-          startDate: '01.06.2022',
-          openingHours: [
-            {
-              weekdays: [1, 2, 3, 4, 5],
-              timeSpanGroups: [
-                {
-                  rule: { type: 'week_every' },
-                  timeSpans: [
-                    {
-                      id: 890207,
-                      description: { fi: null, sv: null, en: null },
-                      end_time: '15:00',
-                      full_day: false,
-                      resource_state: ResourceState.OPEN,
-                      start_time: '10:00',
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              weekdays: [6, 7],
-              timeSpanGroups: [
-                {
-                  rule: { type: 'week_every' },
-                  timeSpans: [
-                    {
-                      id: 890208,
-                      description: { fi: null, sv: null, en: null },
-                      end_time: null,
-                      full_day: false,
-                      resource_state: ResourceState.CLOSED,
-                      start_time: null,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-          id: 1039083,
-          resourceState: ResourceState.UNDEFINED,
-          override: false,
-        },
-        {
-          name: { fi: 'Juhannus', sv: '', en: '' },
-          endDate: '26.06.2022',
-          fixed: true,
-          startDate: '24.06.2022',
-          openingHours: [
-            {
-              weekdays: [1, 2, 3, 4, 5],
-              timeSpanGroups: [
-                {
-                  rule: { type: 'week_every' },
-                  timeSpans: [
-                    {
-                      id: 889998,
-                      description: { fi: null, sv: null, en: null },
-                      end_time: null,
-                      full_day: true,
-                      resource_state: ResourceState.OPEN,
-                      start_time: null,
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              weekdays: [6, 7],
-              timeSpanGroups: [
-                {
-                  rule: { type: 'week_every' },
-                  timeSpans: [
-                    {
-                      id: 889999,
-                      description: { fi: null, sv: null, en: null },
-                      end_time: null,
-                      full_day: false,
-                      resource_state: ResourceState.CLOSED,
-                      start_time: null,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-          id: 1039084,
-          resourceState: ResourceState.UNDEFINED,
-          override: false,
-        },
-        {
-          name: { fi: 'Heinäkuun aukiolot', sv: '', en: '' },
-          endDate: '31.07.2022',
-          fixed: true,
-          startDate: '01.07.2022',
-          openingHours: [
-            {
-              weekdays: [1, 2, 3, 4, 5],
-              timeSpanGroups: [
-                {
-                  rule: { type: 'week_every' },
-                  timeSpans: [
-                    {
-                      id: 889630,
-                      description: { fi: null, sv: null, en: null },
-                      end_time: null,
-                      full_day: false,
-                      resource_state: ResourceState.OPEN,
-                      start_time: null,
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              weekdays: [6, 7],
-              timeSpanGroups: [
-                {
-                  rule: { type: 'week_every' },
-                  timeSpans: [
-                    {
-                      id: 889631,
-                      description: { fi: null, sv: null, en: null },
-                      end_time: null,
-                      full_day: false,
-                      resource_state: ResourceState.CLOSED,
-                      start_time: null,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-          id: 1041197,
-          resourceState: ResourceState.UNDEFINED,
-          override: false,
-        },
-      ])?.id
-    ).toEqual(1039083);
+  describe('getActiveDatePeriods', () => {
+    it('should return one date period', () => {
+      expect(
+        getActiveDatePeriods('2022-03-23', datePeriods).map((d) => d.id)
+      ).toEqual([1041529]);
+    });
+
+    it('should return two overlapping date periods', () => {
+      expect(
+        getActiveDatePeriods('2022-06-20', datePeriods).map((d) => d.id)
+      ).toEqual([1041529, 1039083]);
+    });
+
+    it('should return one exceptional date period', () => {
+      expect(
+        getActiveDatePeriods('2022-06-24', datePeriods).map((d) => d.id)
+      ).toEqual([1039084]);
+    });
+
+    it('should return shortest exceptional date period in case of overlapping exceptional ones', () => {
+      expect(
+        getActiveDatePeriods('2023-05-18', datePeriods).map((d) => d.id)
+      ).toEqual([1039079]);
+    });
   });
 
   describe('isHoliday', () => {

--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -264,6 +264,10 @@ export type DatePeriod = {
   resourceState?: ResourceState;
 };
 
+export type ActiveDatePeriod = {
+  isActive: boolean;
+} & DatePeriod;
+
 export type PreviewOpeningHours = {
   timeSpans: TimeSpan[];
   weekdays: number[];

--- a/src/components/opening-period/OpeningPeriod.test.tsx
+++ b/src/components/opening-period/OpeningPeriod.test.tsx
@@ -4,13 +4,13 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { datePeriodOptions } from '../../../test/fixtures/api-options';
 import { datePeriod } from '../../../test/fixtures/date-period';
 import {
-  DatePeriod,
+  ActiveDatePeriod,
   Language,
   UiDatePeriodConfig,
 } from '../../common/lib/types';
 import OpeningPeriod from './OpeningPeriod';
 
-const testDatePeriod: DatePeriod = datePeriod;
+const testDatePeriod: ActiveDatePeriod = { ...datePeriod, isActive: false };
 const testDatePeriodOptions: UiDatePeriodConfig = datePeriodOptions;
 
 describe(`<OpeningPeriod />`, () => {

--- a/src/components/opening-period/OpeningPeriod.tsx
+++ b/src/components/opening-period/OpeningPeriod.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {
   Language,
-  DatePeriod,
   UiDatePeriodConfig,
   ResourceState,
+  ActiveDatePeriod,
 } from '../../common/lib/types';
 import { formatDateRange } from '../../common/utils/date-time/format';
 import './OpeningPeriod.scss';
@@ -12,7 +12,6 @@ import OpeningPeriodAccordion from '../opening-period-accordion/OpeningPeriodAcc
 import { getDatePeriodName } from '../../common/helpers/opening-hours-helpers';
 
 const OpeningPeriod = ({
-  current = false,
   datePeriod,
   datePeriodConfig,
   editUrl,
@@ -20,8 +19,7 @@ const OpeningPeriod = ({
   deletePeriod,
   initiallyOpen = false,
 }: {
-  current?: boolean;
-  datePeriod: DatePeriod;
+  datePeriod: ActiveDatePeriod;
   datePeriodConfig?: UiDatePeriodConfig;
   editUrl: string;
   language: Language;
@@ -43,7 +41,7 @@ const OpeningPeriod = ({
     }}
     editUrl={editUrl}
     initiallyOpen={initiallyOpen}
-    isActive={current}>
+    isActive={datePeriod.isActive}>
     <div className="date-period-details-container">
       {datePeriod.resourceState === ResourceState.CLOSED ? (
         'Suljettu'

--- a/src/components/opening-periods-list/OpeningPeriodsList.tsx
+++ b/src/components/opening-periods-list/OpeningPeriodsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { getActiveDatePeriod } from '../../common/helpers/opening-hours-helpers';
 import {
+  ActiveDatePeriod,
   DatePeriod,
   Language,
   UiDatePeriodConfig,
@@ -33,7 +33,7 @@ const OpeningPeriodsList = ({
   addNewOpeningPeriodButtonDataTest: string;
   addDatePeriodButtonText: string;
   title: string;
-  datePeriods: DatePeriod[];
+  datePeriods: ActiveDatePeriod[];
   datePeriodConfig?: UiDatePeriodConfig;
   theme: PeriodsListTheme;
   emptyState: string;
@@ -44,10 +44,6 @@ const OpeningPeriodsList = ({
   editUrl: (datePeriod: DatePeriod) => string;
 }): JSX.Element => {
   const ref = React.useRef<HTMLButtonElement>(null);
-  const currentDatePeriod = getActiveDatePeriod(
-    new Date().toISOString().split('T')[0],
-    datePeriods
-  );
 
   return (
     <OpeningPeriodsSection
@@ -61,10 +57,9 @@ const OpeningPeriodsList = ({
       theme={theme}
       title={title}>
       {datePeriods.length > 0 ? (
-        datePeriods.map((datePeriod: DatePeriod, index) => (
+        datePeriods.map((datePeriod, index) => (
           <OpeningPeriod
             key={datePeriod.id}
-            current={currentDatePeriod === datePeriod}
             datePeriodConfig={datePeriodConfig}
             editUrl={editUrl(datePeriod)}
             datePeriod={datePeriod}

--- a/src/components/resource-opening-hours/ResourceOpeningHours.tsx
+++ b/src/components/resource-opening-hours/ResourceOpeningHours.tsx
@@ -3,13 +3,14 @@ import { partition } from 'lodash';
 import { Notification } from 'hds-react';
 import {
   Language,
-  DatePeriod,
   Resource,
   UiDatePeriodConfig,
+  ActiveDatePeriod,
 } from '../../common/lib/types';
 import api from '../../common/utils/api/api';
 import {
   apiDatePeriodToDatePeriod,
+  getActiveDatePeriods,
   isHolidayOrEve,
 } from '../../common/helpers/opening-hours-helpers';
 import { getDatePeriodFormConfig } from '../../services/datePeriodFormConfig';
@@ -35,7 +36,7 @@ const ResourceOpeningHours = ({
     UiDatePeriodConfig
   >();
   const [[normalDatePeriods, exceptions], setDividedDatePeriods] = useState<
-    [DatePeriod[], DatePeriod[]]
+    [ActiveDatePeriod[], ActiveDatePeriod[]]
   >([[], []]);
   const [isLoading, setLoading] = useState(false);
   const fetchDatePeriods = async (id: number): Promise<void> => {
@@ -45,8 +46,16 @@ const ResourceOpeningHours = ({
         api.getDatePeriods(id),
         getDatePeriodFormConfig(),
       ]);
+      const datePeriods = apiDatePeriods.map(apiDatePeriodToDatePeriod);
+      const activeDatePeriods = getActiveDatePeriods(
+        new Date().toISOString().split('T')[0],
+        datePeriods
+      );
       const datePeriodLists = partition(
-        apiDatePeriods.map(apiDatePeriodToDatePeriod),
+        datePeriods.map((datePeriod) => ({
+          ...datePeriod,
+          isActive: activeDatePeriods.includes(datePeriod),
+        })),
         (datePeriod) => !datePeriod.override
       );
       setDividedDatePeriods(datePeriodLists);


### PR DESCRIPTION
# Context
Currently, the date period list was showing the shortest date period as the active one. There was also no separation between normal and exception date periods so both normal dates and exception dates were shown as active at the same time.

# Solution
Resolve active date periods from all date periods.
- If there are multiple overlapping normal dates for the current date all of those periods should be shown as active
- If there are exception dates for the current date those will take precedence
- If there are multiple overlapping exception dates the shortest one is active

# Future
Remove the logic from the UI altogether and leverage API for that. Currently there is same kind of logic in the opening_hours endpoint.