### PR TITLE
Hide time range when 24h selected and re-order inputs

### DIFF
--- a/src/common/helpers/opening-hours-helpers.ts
+++ b/src/common/helpers/opening-hours-helpers.ts
@@ -43,11 +43,11 @@ const toApiTimeSpan = (group: number | undefined, days: number[]) => (
 ): ApiTimeSpan => ({
   id: timeSpan.id,
   description: timeSpan.description,
-  end_time: timeSpan.end_time || null,
+  end_time: (!timeSpan.full_day && timeSpan.end_time) || null,
   full_day: timeSpan.full_day,
   group,
   resource_state: timeSpan.resource_state,
-  start_time: timeSpan.start_time || null,
+  start_time: (!timeSpan.full_day && timeSpan.start_time) || null,
   weekdays: days,
   end_time_on_next_day:
     (timeSpan.start_time &&

--- a/src/components/time-span/TimeSpan.scss
+++ b/src/components/time-span/TimeSpan.scss
@@ -5,13 +5,11 @@
   display: grid;
   gap: 0.5rem;
   grid-template-columns: 1fr 1fr;
-  width: 100%;
-  max-width: max-content;
 }
 
 @media screen and (min-width: $breakpoint-s) {
   .time-span {
-    grid-template-columns: auto 70px 1fr 1fr;
+    grid-template-columns: 70px auto 1fr 1fr;
   }
 }
 
@@ -51,7 +49,7 @@
     order: 1;
   }
 
-  @media screen and (min-width: $breakpoint-m) {
+  @media screen and (min-width: $breakpoint-s) {
     & > .time-span__descriptions {
       grid-column: 1/5;
       order: 2;
@@ -76,19 +74,31 @@
   grid-column: 1/3;
 }
 
-@media screen and (min-width: $breakpoint-m) {
+@media screen and (min-width: $breakpoint-s) {
   .time-span__range {
     grid-column: auto;
   }
 }
 
 .time-span__resource-state-select {
-  width: 265px;
+  grid-column: 1/3;
+}
+
+@media screen and (min-width: $breakpoint-s) {
+  .time-span__resource-state-select {
+    grid-column: auto;
+    width: 265px;
+  }
 }
 
 .time-span__full-day-checkbox-container {
-  display: flex;
-  justify-content: center;
+  grid-column: 1/3;
+}
+
+@media screen and (min-width: $breakpoint-s) {
+  .time-span__full-day-checkbox-container {
+    grid-column: auto;
+  }
 }
 
 .time-span__full-day-checkbox {

--- a/src/components/time-span/TimeSpan.scss
+++ b/src/components/time-span/TimeSpan.scss
@@ -9,7 +9,7 @@
 
 @media screen and (min-width: $breakpoint-s) {
   .time-span {
-    grid-template-columns: 70px auto 1fr 1fr;
+    grid-template-columns: auto auto auto 1fr;
   }
 }
 
@@ -98,12 +98,19 @@
 @media screen and (min-width: $breakpoint-s) {
   .time-span__full-day-checkbox-container {
     grid-column: auto;
+    padding: 0 0.5rem;
   }
 }
 
 .time-span__full-day-checkbox {
-  margin-top: 2.75rem;
+  margin-top: 1rem;
   padding-bottom: 1rem;
+}
+
+@media screen and (min-width: $breakpoint-s) {
+  .time-span__full-day-checkbox {
+    margin-top: 2.75rem;
+  }
 }
 
 @media screen and (min-width: $breakpoint-m) {

--- a/src/components/time-span/TimeSpan.tsx
+++ b/src/components/time-span/TimeSpan.tsx
@@ -93,60 +93,6 @@ const TimeSpan = ({
       aria-label={groupLabel}>
       {displayStartAndEndTimes && (
         <>
-          <div className="time-span__range">
-            <Controller
-              control={control}
-              name={`${namePrefix}.start_time`}
-              defaultValue={item?.start_time ?? ''}
-              render={({ field, fieldState }): JSX.Element => (
-                <TimeInput
-                  disabled={disabled || fullDay}
-                  errorText={fieldState.error?.message}
-                  hoursLabel="tunnit"
-                  id={getUiId([namePrefix, 'start-time'])}
-                  invalid={!!fieldState.error?.message}
-                  label="Alkaa klo"
-                  minutesLabel="minuutit"
-                  name={field.name}
-                  onBlur={field.onBlur}
-                  onChange={field.onChange}
-                  ref={(e) => {
-                    field.ref(e);
-                    if (innerRef) {
-                      // eslint-disable-next-line no-param-reassign
-                      innerRef.current = e;
-                    }
-                  }}
-                  required
-                  value={field.value ?? ''}
-                />
-              )}
-              rules={timeInputRules}
-            />
-            <Controller
-              control={control}
-              name={`${namePrefix}.end_time`}
-              defaultValue={item?.end_time ?? ''}
-              render={({ field, fieldState }): JSX.Element => (
-                <TimeInput
-                  disabled={disabled || fullDay}
-                  errorText={fieldState.error?.message}
-                  hoursLabel="tunnit"
-                  id={getUiId([namePrefix, 'end-time'])}
-                  invalid={!!fieldState.error?.message}
-                  label="Päättyy klo"
-                  minutesLabel="minuutit"
-                  name={field.name}
-                  onBlur={field.onBlur}
-                  onChange={field.onChange}
-                  ref={field.ref}
-                  required
-                  value={field.value ?? ''}
-                />
-              )}
-              rules={timeInputRules}
-            />
-          </div>
           <Controller
             defaultValue={item?.full_day ?? false}
             render={({ field }): JSX.Element => (
@@ -161,12 +107,71 @@ const TimeSpan = ({
                     field.onChange(e.target.checked);
                   }}
                   checked={field.value}
+                  ref={(e) => {
+                    field.ref(e);
+                    if (innerRef) {
+                      // eslint-disable-next-line no-param-reassign
+                      innerRef.current = e;
+                    }
+                  }}
                 />
               </div>
             )}
             control={control}
             name={`${namePrefix}.full_day`}
           />
+          {!fullDay && (
+            <>
+              <div className="time-span__range">
+                <Controller
+                  control={control}
+                  name={`${namePrefix}.start_time`}
+                  defaultValue={item?.start_time ?? ''}
+                  render={({ field, fieldState }): JSX.Element => (
+                    <TimeInput
+                      disabled={disabled}
+                      errorText={fieldState.error?.message}
+                      hoursLabel="tunnit"
+                      id={getUiId([namePrefix, 'start-time'])}
+                      invalid={!!fieldState.error?.message}
+                      label="Alkaa klo"
+                      minutesLabel="minuutit"
+                      name={field.name}
+                      onBlur={field.onBlur}
+                      onChange={field.onChange}
+                      required
+                      ref={field.ref}
+                      value={field.value ?? ''}
+                    />
+                  )}
+                  rules={timeInputRules}
+                />
+                <Controller
+                  control={control}
+                  name={`${namePrefix}.end_time`}
+                  defaultValue={item?.end_time ?? ''}
+                  render={({ field, fieldState }): JSX.Element => (
+                    <TimeInput
+                      disabled={disabled}
+                      errorText={fieldState.error?.message}
+                      hoursLabel="tunnit"
+                      id={getUiId([namePrefix, 'end-time'])}
+                      invalid={!!fieldState.error?.message}
+                      label="Päättyy klo"
+                      minutesLabel="minuutit"
+                      name={field.name}
+                      onBlur={field.onBlur}
+                      onChange={field.onChange}
+                      ref={field.ref}
+                      required
+                      value={field.value ?? ''}
+                    />
+                  )}
+                  rules={timeInputRules}
+                />
+              </div>
+            </>
+          )}
         </>
       )}
       <Controller

--- a/src/components/time-span/TimeSpans.tsx
+++ b/src/components/time-span/TimeSpans.tsx
@@ -1,5 +1,5 @@
 import { IconPlusCircle } from 'hds-react';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import {
   areStartAndEndTimesAllowed,
@@ -42,6 +42,7 @@ const TimeSpans = ({
     name: namePrefix,
   });
   const ref = useRef<HTMLInputElement>(null);
+  const [timeSpansChanged, setTimeSpansChanged] = useState(false);
 
   // Without this for some reason the key inference breaks :(
   const first = 0 as number;
@@ -78,12 +79,19 @@ const TimeSpans = ({
     remove,
   ]);
 
+  useEffect(() => {
+    if (timeSpansChanged) {
+      ref.current?.focus();
+      setTimeSpansChanged(false);
+    }
+  }, [timeSpansChanged]);
+
   return (
     <div className="time-spans">
       {fields.map((field, i) => (
         <TimeSpan
           key={field.id}
-          innerRef={i === fields.length - 2 ? ref : undefined}
+          innerRef={i === fields.length - 1 ? ref : undefined}
           openingHoursIdx={openingHoursIdx}
           timeSpanGroupIdx={timeSpanGroupIdx}
           i={i}
@@ -94,8 +102,8 @@ const TimeSpans = ({
             i === 0
               ? undefined
               : (): void => {
-                  ref.current?.focus();
                   remove(i);
+                  setTimeSpansChanged(true);
                 }
           }
         />
@@ -106,7 +114,10 @@ const TimeSpans = ({
             dataTest={getUiId([namePrefix, 'add-time-span-button'])}
             className="add-time-span-button"
             iconLeft={<IconPlusCircle />}
-            onClick={(): void => append(defaultTimeSpan)}
+            onClick={(): void => {
+              append(defaultTimeSpan, { shouldFocus: false });
+              setTimeSpansChanged(true);
+            }}
             type="button">
             Lisää aukiolomääritys
           </SupplementaryButton>


### PR DESCRIPTION
# Context & problem

At the moment it is not possible to define opening hours as 24h since the validation does not take that selection into account.

![image](https://user-images.githubusercontent.com/660756/221146755-e1ee33e0-a9c9-4b06-9cfd-c38ddb8ef437.png)

# Proposed solution

When the user wants to define opening hours to apply 24 hours then the time range will be hidden. This way we can make the user flow a bit smoother since unneeded fields are hidden. Also since the fields are not visible the validation for the fields won't fire thus allowing the user can save the date period.

The first idea was to flip the time range inputs and 24h checkbox to make the conceptual flow better but then it came evident that it would be better to flip the time range and the resource state since resource state affects to the 24h and time range inputs visibility.

# Changes

- Flip time range and resource state inputs positions
- If 24h is selected change the start time and end time to null
- When a time span row is added or removed focus on the resource state select accordingly
- Improvements to the form responsiveness 

<img width="816" alt="image" src="https://user-images.githubusercontent.com/660756/221193711-98abc8a9-0a7a-487e-8871-dcf161f695bc.png">

<img width="812" alt="image" src="https://user-images.githubusercontent.com/660756/221193753-b49e0af2-2137-4bdb-9b07-84be80e1b5e7.png">

<img width="817" alt="image" src="https://user-images.githubusercontent.com/660756/221193853-e1d452ba-3376-4d14-9bed-57615613927c.png">