### PR TITLE
Add mobile actions menu

### DIFF
--- a/src/components/opening-hours-preview/OpeningHoursPreview.scss
+++ b/src/components/opening-hours-preview/OpeningHoursPreview.scss
@@ -5,6 +5,13 @@
   margin-bottom: 1.5rem;
   padding: 3px 0;
   table-layout: fixed;
+  width: 100%;
+}
+
+@media screen and (min-width: $breakpoint-s) {
+  .opening-hours-preview-table {
+    width: revert;
+  }
 }
 
 .opening-hours-preview-table:last-child {

--- a/src/components/opening-period/OpeningPeriod.scss
+++ b/src/components/opening-period/OpeningPeriod.scss
@@ -33,23 +33,46 @@
 }
 
 .opening-period-dates {
-  flex-basis: 18ch;
+  align-items: stretch;
+  flex-basis: 100%;
+  flex-direction: column;
   flex-grow: 1;
+  gap: $spacing-2-xs $spacing-s;
   line-height: $lineheight-l;
+  margin-bottom: $spacing-s;
+  order: 1;
+}
+
+@media screen and (min-width: $breakpoint-s) {
+  .opening-period-dates {
+    align-items: center;
+    flex-basis: 18ch;
+    flex-direction: row;
+    margin-bottom: revert;
+    order: revert;
+  }
 }
 
 .opening-period-dates-status {
-  flex: 1;
+  padding: 0 $spacing-5-xl 0 $spacing-s;
+  white-space: nowrap;
 }
 
 .opening-period-title {
   display: flex;
   justify-content: normal;
+  margin: 0;
+  margin-left: $spacing-m;
 }
 
-.opening-period-edit-link {
+.opening-period-action-edit {
   color: $color-black;
-  margin-left: auto;
+}
+
+@media screen and (min-width: $breakpoint-s) {
+  .opening-period-action-delete {
+    margin-right: $spacing-s;
+  }
 }
 
 .date-period-details-container {
@@ -74,16 +97,43 @@
 
 .opening-period-actions {
   flex: 1 1;
-}
-
-@media screen and (min-width: $breakpoint-l) {
-  .opening-period-actions {
-    flex: 0.8 0.8;
-  }
+  justify-content: flex-end;
+  gap: 0;
 }
 
 @media screen and (min-width: $breakpoint-xl) {
   .opening-period-actions {
     flex: 0.65 0.65;
   }
+}
+
+.opening-period-actions-menu {
+  position: relative;
+}
+
+.opening-period-actions-menu-items {
+  align-items: stretch;
+  background: white;
+  border: 1px solid black;
+  display: flex;
+  flex-direction: column;
+  left: -1px;
+  position: absolute;
+}
+
+.opening-period-actions-menu-item {
+  background: transparent;
+  border: 0;
+  color: $color-black;
+  display: block;
+  line-height: $lineheight-l;
+  margin: 0;
+  padding: $spacing-xs $spacing-s;
+  text-align: left;
+  text-decoration: none;
+}
+
+.opening-period-actions-menu-item:hover {
+  background: $color-bus;
+  color: $color-white;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -62,7 +62,7 @@ code {
   cursor: pointer;
   display: inline-block;
   font: inherit;
-  padding: var(--spacing-xs) var(--spacing-s);
+  padding: var(--spacing-xs);
 
   &:hover {
     background-color: var(--button-icon-hover-background-color);
@@ -71,5 +71,9 @@ code {
   &:focus {
     border-radius: 0;
     outline: 2px solid var(--button-icon-focus-border-color);
+  }
+
+  & svg {
+    display: flex;
   }
 }


### PR DESCRIPTION
Currently the period list is a bit broken in mobile view.

Current state:
<img width="380" alt="image" src="https://user-images.githubusercontent.com/660756/224681948-b510703a-bbc7-4798-b2bb-e59b6a2c8603.png">

Proposed solution:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/660756/224682394-e092097e-cc3c-40ba-8178-c537f54ee74c.png">

<img width="379" alt="image" src="https://user-images.githubusercontent.com/660756/224682436-b7d3867f-9a66-4a5a-a716-814bab53d259.png">



