### PR TITLE
Fix a11y e2e on opening period form

### DIFF
--- a/src/components/opening-hours-form/OpeningHoursForm.tsx
+++ b/src/components/opening-hours-form/OpeningHoursForm.tsx
@@ -179,7 +179,7 @@ const OpeningHoursForm = ({
                       resourceStates={resourceStates}
                     />
                   </section>
-                  <aside className="opening-hours-form__aside">
+                  <div className="opening-hours-form__aside">
                     <OpeningHoursFormPreview
                       datePeriod={formValues}
                       resourceStates={resourceStates}
@@ -192,7 +192,7 @@ const OpeningHoursForm = ({
                         Järjestä päiväryhmät viikonpäivien mukaan
                       </SupplementaryButton>
                     </div>
-                  </aside>
+                  </div>
                 </div>
               )}
             </section>


### PR DESCRIPTION
Fix issue `Aside must not be contained in another landmark` thrown in e2e https://dev.azure.com/City-of-Helsinki/hauki/_build/results?buildId=80569&view=logs&j=c9c218a4-8067-573a-e9a0-d61992a540d8&t=41fab671-d748-5666-e4d2-b028dac5244d. 

This needs some rethinking on how to structure the opening period form page if we want to use the preview as an aside. 