### PR TITLE
Hauki 574 selected resources view (and Hauki 579)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import './App.scss';
 import { Language } from './common/lib/types';
 import PrivateResourceRoute from './components/router/PrivateResourceRoute';
 import ResourcePage from './pages/ResourcePage';
+import ResourceBatchUpdatePage from './pages/ResourceBatchUpdatePage';
 import AddNormalOpeningHoursPage from './pages/AddNormalOpeningHoursPage';
 import EditNormalOpeningHoursPage from './pages/EditNormalOpeningHoursPage';
 import EditHolidaysPage from './pages/EditHolidaysPage';
@@ -144,6 +145,31 @@ const App = (): JSX.Element => {
                           <ResourcePage
                             id={id}
                             childId={childId}
+                            targetResourcesString={targetResourcesStr}
+                          />
+                        </Main>
+                      </NavigationAndFooterWrapper>
+                    )
+                  );
+                }}
+              />
+              <PrivateResourceRoute
+                id="resource-batch-update-route"
+                exact
+                path={['/resource/:id/batch']}
+                render={({
+                  match,
+                }: RouteComponentProps<{
+                  id?: string;
+                }>) => {
+                  const { id } = match.params;
+
+                  return (
+                    id && (
+                      <NavigationAndFooterWrapper>
+                        <Main id="main">
+                          <ResourceBatchUpdatePage
+                            id={id}
                             targetResourcesString={targetResourcesStr}
                           />
                         </Main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,7 +143,7 @@ const App = (): JSX.Element => {
                       <NavigationAndFooterWrapper>
                         <Main id="main">
                           <ResourcePage
-                            id={id}
+                            mainResourceId={id}
                             childId={childId}
                             targetResourcesString={targetResourcesStr}
                           />
@@ -169,7 +169,7 @@ const App = (): JSX.Element => {
                       <NavigationAndFooterWrapper>
                         <Main id="main">
                           <ResourceBatchUpdatePage
-                            id={id}
+                            mainResourceId={id}
                             targetResourcesString={targetResourcesStr}
                           />
                         </Main>

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -232,6 +232,14 @@ export default {
   getResource: (id: string): Promise<Resource> =>
     apiGet<Resource>({ path: `${resourceBasePath}/${id}` }),
 
+  getResources: (ids: string[]): Promise<Resource[]> =>
+    apiGet<{ results: Resource[] }>({
+      path: `${resourceBasePath}`,
+      parameters: {
+        resource_ids: ids.join(','),
+      },
+    }).then((response) => response.results),
+
   getChildResourcesByParentId: (id: number): Promise<Resource[]> =>
     apiGet<{ results: Resource[] }>({
       path: `${resourceBasePath}`,

--- a/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.test.tsx
+++ b/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.test.tsx
@@ -11,7 +11,7 @@ import ResourcePeriodsCopyFieldset, {
 const testCopyResourceData: TargetResourcesProps = {
   mainResourceId: 1111,
   mainResourceName: 'testMainResource',
-  targetResources: [{id:'tprek: 1122', name:'testTargetResource'}],
+  targetResources: [{ id: 'tprek: 1122', name: 'testTargetResource' }],
 };
 
 describe(`<ResourcePeriodsCopyFieldset/>`, () => {
@@ -54,7 +54,7 @@ describe(`<ResourcePeriodsCopyFieldset/>`, () => {
     await waitFor(async () => {
       expect(apiCopySpy).toHaveBeenCalledWith(
         testCopyResourceData.mainResourceId,
-        testCopyResourceData.targetResources.map((resource) => resource.id),
+        testCopyResourceData.targetResources?.map((resource) => resource.id)
       );
       expect(toastSuccessSpy).toHaveBeenCalled();
       expect(onChange).toHaveBeenCalledWith({

--- a/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.test.tsx
+++ b/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.test.tsx
@@ -10,8 +10,8 @@ import ResourcePeriodsCopyFieldset, {
 
 const testCopyResourceData: TargetResourcesProps = {
   mainResourceId: 1111,
-  mainResourceName: 'testTargetResource',
-  targetResources: ['tprek: 1122'],
+  mainResourceName: 'testMainResource',
+  targetResources: [{id:'tprek: 1122', name:'testTargetResource'}],
 };
 
 describe(`<ResourcePeriodsCopyFieldset/>`, () => {
@@ -54,7 +54,7 @@ describe(`<ResourcePeriodsCopyFieldset/>`, () => {
     await waitFor(async () => {
       expect(apiCopySpy).toHaveBeenCalledWith(
         testCopyResourceData.mainResourceId,
-        testCopyResourceData.targetResources
+        testCopyResourceData.targetResources.map((resource) => resource.id),
       );
       expect(toastSuccessSpy).toHaveBeenCalled();
       expect(onChange).toHaveBeenCalledWith({

--- a/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.tsx
+++ b/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.tsx
@@ -20,8 +20,8 @@ const ResourcePeriodsCopyFieldset = ({
   mainResourceName,
   mainResourceId,
   targetResources = [],
-  onChange,
   modified,
+  onChange,
 }: TargetResourcesProps & {
   onChange: (value: TargetResourcesProps | undefined) => void;
 }): JSX.Element => {

--- a/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.tsx
+++ b/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.tsx
@@ -12,7 +12,7 @@ import toast from '../notification/Toast';
 export type TargetResourcesProps = {
   mainResourceName?: string;
   mainResourceId?: number;
-  targetResources?: string[];
+  targetResources?: { id: string; name?: string }[];
   modified?: string;
 };
 
@@ -36,7 +36,10 @@ const ResourcePeriodsCopyFieldset = ({
     }
 
     try {
-      await api.copyDatePeriods(mainResourceId, targetResources);
+      await api.copyDatePeriods(
+        mainResourceId,
+        targetResources.map((item) => item.id)
+      );
       toast.success({
         dataTestId: 'period-copy-success',
         label:

--- a/src/hooks/useGoToResourceBatchUpdatePage.ts
+++ b/src/hooks/useGoToResourceBatchUpdatePage.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+import { useHistory, useRouteMatch } from 'react-router-dom';
+
+const useGotToResourceBatchUpdataPage = (): (() => void) => {
+  const history = useHistory();
+  const {
+    params: { parentId, id: resourceId },
+  } = useRouteMatch<{
+    parentId?: string;
+    id?: string;
+  }>();
+
+  return useCallback(() => {
+    if (!parentId && !resourceId) {
+      throw new Error('Invalid route. No resource id found from the path.');
+    }
+
+    const resourcePath = parentId
+      ? `${parentId}/child/${resourceId}`
+      : resourceId;
+
+    history.push(`/resource/${resourcePath}/batch`);
+  }, [history, parentId, resourceId]);
+};
+
+export default useGotToResourceBatchUpdataPage;

--- a/src/pages/ResourceBatchUpdatePage.scss
+++ b/src/pages/ResourceBatchUpdatePage.scss
@@ -9,7 +9,7 @@
     display: flex;
     flex-direction: column;
     gap: $spacing-s;
-    padding: $spacing-s $spacing-l;
+    padding: $spacing-m $spacing-l;
     background-color: white;
     position: relative;
 
@@ -40,6 +40,7 @@
     display: flex;
     gap: $spacing-layout-xs;
     background-color: transparent;
+    align-items: flex-start;
   }
 
   .button-confirm {

--- a/src/pages/ResourceBatchUpdatePage.scss
+++ b/src/pages/ResourceBatchUpdatePage.scss
@@ -13,8 +13,9 @@
     background-color: white;
     position: relative;
 
-    > *, .list-options {
-      margin: 0px;
+    > *,
+    .list-options {
+      margin: 0;
     }
   }
 
@@ -22,10 +23,10 @@
     display: flex;
     justify-content: space-between;
     background-color: transparent;
-    padding: 0px;
+    padding: 0;
 
     h1 {
-      margin: 0px;
+      margin: 0;
     }
   }
 
@@ -49,6 +50,6 @@
 
   .button-close {
     position: absolute;
-    right: 0px;
+    right: 0;
   }
 }

--- a/src/pages/ResourceBatchUpdatePage.scss
+++ b/src/pages/ResourceBatchUpdatePage.scss
@@ -1,0 +1,53 @@
+@import 'node_modules/hds-design-tokens/lib/all.scss';
+
+.resource-batch-update-page {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-layout-m;
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-s;
+    padding: $spacing-s $spacing-l;
+    background-color: white;
+    position: relative;
+
+    > *, .list-options {
+      margin: 0px;
+    }
+  }
+
+  .section-title {
+    display: flex;
+    justify-content: space-between;
+    background-color: transparent;
+    padding: 0px;
+
+    h1 {
+      margin: 0px;
+    }
+  }
+
+  .section-resources {
+    td {
+      padding-top: 2px;
+      padding-bottom: 2px;
+    }
+  }
+
+  .section-resource-update {
+    display: flex;
+    gap: $spacing-layout-xs;
+    background-color: transparent;
+  }
+
+  .button-confirm {
+    margin-top: $spacing-s;
+  }
+
+  .button-close {
+    position: absolute;
+    right: 0px;
+  }
+}

--- a/src/pages/ResourceBatchUpdatePage.test.tsx
+++ b/src/pages/ResourceBatchUpdatePage.test.tsx
@@ -275,30 +275,30 @@ describe(`<ResourceBatchUpdatePage />`, () => {
     const removeButton = td.querySelector('button') as Element;
     fireEvent.click(removeButton);
 
-    const testTargetResourceDataAfterRemove = {
+    const afterRemove = {
       ...testTargetResourceData,
       targetResources: [
-        testTargetResourceData.targetResources[0],
-        testTargetResourceData.targetResources[2],
+        testTargetResourceData.targetResources?.at(0),
+        testTargetResourceData.targetResources?.at(2),
       ],
     };
 
     const storedData = sessionStorage.getItem('targetResources');
 
-    expect(storedData).toEqual(
-      JSON.stringify(testTargetResourceDataAfterRemove)
-    );
+    expect(afterRemove.targetResources?.at(0)).toBeDefined();
+    expect(afterRemove.targetResources?.at(1)).toBeDefined();
+    expect(storedData).toEqual(JSON.stringify(afterRemove));
     expect(getByTestId(container, 'id-0')).toHaveTextContent(
-      testTargetResourceDataAfterRemove.targetResources[0].id
+      afterRemove.targetResources?.at(0)?.id || ''
     );
     expect(getByTestId(container, 'resource-0')).toHaveTextContent(
-      testTargetResourceDataAfterRemove.targetResources[0].name
+      afterRemove.targetResources?.at(0)?.name || ''
     );
     expect(getByTestId(container, 'id-1')).toHaveTextContent(
-      testTargetResourceDataAfterRemove.targetResources[1].id
+      afterRemove.targetResources?.at(1)?.id || ''
     );
     expect(getByTestId(container, 'resource-1')).toHaveTextContent(
-      testTargetResourceDataAfterRemove.targetResources[1].name
+      afterRemove.targetResources?.at(1)?.name || ''
     );
   });
 });

--- a/src/pages/ResourceBatchUpdatePage.test.tsx
+++ b/src/pages/ResourceBatchUpdatePage.test.tsx
@@ -10,87 +10,118 @@ import {
 } from '@testing-library/react';
 import ResourceBatchUpdatePage, {
   ResourceBatchUpdatePageProps,
+  ResourceWithOrigins,
 } from './ResourceBatchUpdatePage';
+import { ResourceType } from '../common/lib/types';
 import api from '../common/utils/api/api';
+import { TargetResourcesProps } from '../components/resource-opening-hours/ResourcePeriodsCopyFieldset';
 
 const testResourceBatchUpdatePagePros: ResourceBatchUpdatePageProps = {
   mainResourceId: 'tprek:10',
   targetResourcesString: 'tprek:11,tprek:12,tprek:13,tprek:14',
 };
 
-const testGetResourceResponse = {
+const testGetResourceResponse: ResourceWithOrigins = {
   id: 1010,
+  modified: '',
   name: { fi: 'test pk 10 fi', sv: 'test pk 10 sv', en: 'test pk 10 en' },
+  description: { fi: '', sv: '', en: '' },
+  address: { fi: '', sv: '', en: '' },
+  extra_data: { citizen_url: '', admin_url: '' },
+  parents: [],
+  children: [],
+  resource_type: ResourceType.UNIT,
   origins: [
     {
       data_source: {
         id: 'tprek',
-        name: { fi: 'Toimipisterekisteri', sv: null, en: null },
+        name: { fi: 'Toimipisterekisteri', sv: '', en: '' },
       },
       origin_id: '10',
     },
     {
-      data_source: { id: 'asti', name: { fi: null, sv: null, en: null } },
+      data_source: { id: 'asti', name: { fi: '', sv: '', en: '' } },
       origin_id: '110',
     },
   ],
 };
 
-const testGetResourcesResponse = [
+const testGetResourcesResponse: ResourceWithOrigins[] = [
   {
     id: 1011,
+    modified: '',
     name: { fi: 'test pk 11 fi', sv: 'test pk 11 sv', en: 'test pk 11 en' },
+    description: { fi: '', sv: '', en: '' },
+    address: { fi: '', sv: '', en: '' },
+    extra_data: { citizen_url: '', admin_url: '' },
+    parents: [],
+    children: [],
+    resource_type: ResourceType.UNIT,
     origins: [
       {
         data_source: {
           id: 'tprek',
-          name: { fi: 'Toimipisterekisteri', sv: null, en: null },
+          name: { fi: 'Toimipisterekisteri', sv: '', en: '' },
         },
         origin_id: '11',
       },
       {
-        data_source: { id: 'asti', name: { fi: null, sv: null, en: null } },
+        data_source: { id: 'asti', name: { fi: '', sv: '', en: '' } },
         origin_id: '111',
       },
     ],
   },
   {
     id: 1012,
+    modified: '',
     name: { fi: 'test pk 12 fi', sv: 'test pk 12 sv', en: 'test pk 12 en' },
+    description: { fi: '', sv: '', en: '' },
+    address: { fi: '', sv: '', en: '' },
+    extra_data: { citizen_url: '', admin_url: '' },
+    parents: [],
+    children: [],
+    resource_type: ResourceType.UNIT,
     origins: [
       {
         data_source: {
           id: 'tprek',
-          name: { fi: 'Toimipisterekisteri', sv: null, en: null },
+          name: { fi: 'Toimipisterekisteri', sv: '', en: '' },
         },
         origin_id: '12',
       },
       {
-        data_source: { id: 'asti', name: { fi: null, sv: null, en: null } },
+        data_source: { id: 'asti', name: { fi: '', sv: '', en: '' } },
         origin_id: '112',
       },
     ],
   },
   {
     id: 1013,
+    modified: '',
     name: { fi: 'test pk 13 fi', sv: 'test pk 13 sv', en: 'test pk 13 en' },
+    description: { fi: '', sv: '', en: '' },
+    address: { fi: '', sv: '', en: '' },
+    extra_data: { citizen_url: '', admin_url: '' },
+    parents: [],
+    children: [],
+    resource_type: ResourceType.UNIT,
     origins: [
       {
         data_source: {
           id: 'tprek',
-          name: { fi: 'Toimipisterekisteri', sv: null, en: null },
+          name: { fi: 'Toimipisterekisteri', sv: '', en: '' },
         },
         origin_id: '13',
       },
       {
-        data_source: { id: 'asti', name: { fi: null, sv: null, en: null } },
+        data_source: { id: 'asti', name: { fi: '', sv: '', en: '' } },
         origin_id: '112',
       },
     ],
   },
 ];
 
-const testTargetResourceData = {
+const testTargetResourceData: TargetResourcesProps = {
   mainResourceId: 1010,
   mainResourceName: 'test pk 10 fi',
   targetResources: [
@@ -119,7 +150,7 @@ const renderPage = () =>
 describe(`<ResourceBatchUpdatePage />`, () => {
   beforeEach(() => {
     const sessionStorageMock = (() => {
-      const store = {};
+      const store: { [key: string]: string } = {};
 
       return {
         getItem: (key: string | number) => store[key] || null,
@@ -178,7 +209,7 @@ describe(`<ResourceBatchUpdatePage />`, () => {
   it('should call get resource api correctly', async () => {
     const apiGetResourceSpy = jest
       .spyOn(api, 'getResource')
-      .mockImplementation(() => Promise.resolve(true));
+      .mockImplementation(() => Promise.resolve(testGetResourceResponse));
 
     renderPage();
 
@@ -192,17 +223,17 @@ describe(`<ResourceBatchUpdatePage />`, () => {
   it('should call get resources api correctly', async () => {
     jest
       .spyOn(api, 'getResource')
-      .mockImplementation(() => Promise.resolve(true));
+      .mockImplementation(() => Promise.resolve(testGetResourceResponse));
 
     const apiGetResourcesSpy = jest
       .spyOn(api, 'getResources')
-      .mockImplementation(() => Promise.resolve(true));
+      .mockImplementation(() => Promise.resolve(testGetResourcesResponse));
 
     renderPage();
 
     await waitFor(async () => {
       expect(apiGetResourcesSpy).toHaveBeenCalledWith(
-        testResourceBatchUpdatePagePros.targetResourcesString.split(',')
+        testResourceBatchUpdatePagePros.targetResourcesString?.split(',')
       );
     });
   });
@@ -241,7 +272,7 @@ describe(`<ResourceBatchUpdatePage />`, () => {
     });
 
     const td = getByTestId(container, 'remove-1');
-    const removeButton = td.querySelector('button');
+    const removeButton = td.querySelector('button') as Element;
     fireEvent.click(removeButton);
 
     const testTargetResourceDataAfterRemove = {

--- a/src/pages/ResourceBatchUpdatePage.test.tsx
+++ b/src/pages/ResourceBatchUpdatePage.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { render, screen, waitFor, fireEvent, getByTestId } from '@testing-library/react';
-import { AppContext } from '../App-context';
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  getByTestId,
+} from '@testing-library/react';
 import ResourceBatchUpdatePage, {
   ResourceBatchUpdatePageProps,
 } from './ResourceBatchUpdatePage';
@@ -11,81 +16,114 @@ import api from '../common/utils/api/api';
 const testResourceBatchUpdatePagePros: ResourceBatchUpdatePageProps = {
   mainResourceId: 'tprek:10',
   targetResourcesString: 'tprek:11,tprek:12,tprek:13,tprek:14',
-}
+};
 
 const testGetResourceResponse = {
-  "id":1010,
-  "name":{"fi":"test pk 10 fi", "sv":"test pk 10 sv", "en":"test pk 10 en"},
-  "origins":[
-    {"data_source":{"id":"tprek", "name":{"fi":"Toimipisterekisteri", "sv":null, "en":null}}, "origin_id":"10"},
-    {"data_source":{"id":"asti", "name":{"fi":null, "sv":null, "en":null}}, "origin_id":"110"}
+  id: 1010,
+  name: { fi: 'test pk 10 fi', sv: 'test pk 10 sv', en: 'test pk 10 en' },
+  origins: [
+    {
+      data_source: {
+        id: 'tprek',
+        name: { fi: 'Toimipisterekisteri', sv: null, en: null },
+      },
+      origin_id: '10',
+    },
+    {
+      data_source: { id: 'asti', name: { fi: null, sv: null, en: null } },
+      origin_id: '110',
+    },
   ],
-}
+};
 
 const testGetResourcesResponse = [
   {
-    "id":1011,
-    "name":{"fi":"test pk 11 fi", "sv":"test pk 11 sv", "en":"test pk 11 en"},
-    "origins":[
-      {"data_source":{"id":"tprek", "name":{"fi":"Toimipisterekisteri", "sv":null, "en":null}}, "origin_id":"11"},
-      {"data_source":{"id":"asti", "name":{"fi":null, "sv":null, "en":null}}, "origin_id":"111"}
+    id: 1011,
+    name: { fi: 'test pk 11 fi', sv: 'test pk 11 sv', en: 'test pk 11 en' },
+    origins: [
+      {
+        data_source: {
+          id: 'tprek',
+          name: { fi: 'Toimipisterekisteri', sv: null, en: null },
+        },
+        origin_id: '11',
+      },
+      {
+        data_source: { id: 'asti', name: { fi: null, sv: null, en: null } },
+        origin_id: '111',
+      },
     ],
   },
   {
-    "id":1012,
-    "name":{"fi":"test pk 12 fi", "sv":"test pk 12 sv", "en":"test pk 12 en"},
-    "origins":[
-      {"data_source":{"id":"tprek", "name":{"fi":"Toimipisterekisteri", "sv":null, "en":null}}, "origin_id":"12"},
-      {"data_source":{"id":"asti", "name":{"fi":null, "sv":null, "en":null}}, "origin_id":"112"}
+    id: 1012,
+    name: { fi: 'test pk 12 fi', sv: 'test pk 12 sv', en: 'test pk 12 en' },
+    origins: [
+      {
+        data_source: {
+          id: 'tprek',
+          name: { fi: 'Toimipisterekisteri', sv: null, en: null },
+        },
+        origin_id: '12',
+      },
+      {
+        data_source: { id: 'asti', name: { fi: null, sv: null, en: null } },
+        origin_id: '112',
+      },
     ],
   },
   {
-    "id":1013,
-    "name":{"fi":"test pk 13 fi", "sv":"test pk 13 sv", "en":"test pk 13 en"},
-    "origins":[
-      {"data_source":{"id":"tprek", "name":{"fi":"Toimipisterekisteri", "sv":null, "en":null}}, "origin_id":"13"},
-      {"data_source":{"id":"asti", "name":{"fi":null, "sv":null, "en":null}}, "origin_id":"112"}
+    id: 1013,
+    name: { fi: 'test pk 13 fi', sv: 'test pk 13 sv', en: 'test pk 13 en' },
+    origins: [
+      {
+        data_source: {
+          id: 'tprek',
+          name: { fi: 'Toimipisterekisteri', sv: null, en: null },
+        },
+        origin_id: '13',
+      },
+      {
+        data_source: { id: 'asti', name: { fi: null, sv: null, en: null } },
+        origin_id: '112',
+      },
     ],
-  }
-]
+  },
+];
 
 const testTargetResourceData = {
-  "mainResourceId": 1010,
-  "mainResourceName": "test pk 10 fi",
-  "targetResources": [
+  mainResourceId: 1010,
+  mainResourceName: 'test pk 10 fi',
+  targetResources: [
     {
-      "id": "tprek:11",
-      "name": "test pk 11 fi"
+      id: 'tprek:11',
+      name: 'test pk 11 fi',
     },
     {
-      "id": "tprek:12",
-      "name": "test pk 12 fi"
+      id: 'tprek:12',
+      name: 'test pk 12 fi',
     },
     {
-      "id": "tprek:13",
-      "name": "test pk 13 fi"
-    }
-  ]
-}
+      id: 'tprek:13',
+      name: 'test pk 13 fi',
+    },
+  ],
+};
 
 const renderPage = () =>
   render(
     <Router>
-      <ResourceBatchUpdatePage
-        {...testResourceBatchUpdatePagePros}
-      />
+      <ResourceBatchUpdatePage {...testResourceBatchUpdatePagePros} />
     </Router>
   );
-
 
 describe(`<ResourceBatchUpdatePage />`, () => {
   beforeEach(() => {
     const sessionStorageMock = (() => {
-      let store = {};
+      const store = {};
 
       return {
-        getItem: (key) => store[key] || null,
-        setItem: (key, value) => {
+        getItem: (key: string | number) => store[key] || null,
+        setItem: (key: string | number, value: { toString: () => string }) => {
           store[key] = value.toString();
         },
       };
@@ -103,6 +141,7 @@ describe(`<ResourceBatchUpdatePage />`, () => {
   it('should show loading indicator', async () => {
     jest
       .spyOn(api, 'getResource')
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       .mockImplementation(() => new Promise(() => {}));
 
     renderPage();
@@ -121,7 +160,9 @@ describe(`<ResourceBatchUpdatePage />`, () => {
         Promise.reject(new Error('Failed to load a resource'))
       );
 
-    await act(async () => {renderPage()});
+    await act(async () => {
+      renderPage();
+    });
 
     await act(async () => {
       expect(await screen.getByRole('heading', { level: 1 })).toHaveTextContent(
@@ -147,7 +188,6 @@ describe(`<ResourceBatchUpdatePage />`, () => {
       );
     });
   });
-
 
   it('should call get resources api correctly', async () => {
     jest
@@ -176,7 +216,9 @@ describe(`<ResourceBatchUpdatePage />`, () => {
       .spyOn(api, 'getResources')
       .mockImplementation(() => Promise.resolve(testGetResourcesResponse));
 
-    await act(async () => {renderPage()});
+    await act(async () => {
+      renderPage();
+    });
 
     const storedData = sessionStorage.getItem('targetResources');
 
@@ -206,16 +248,26 @@ describe(`<ResourceBatchUpdatePage />`, () => {
       ...testTargetResourceData,
       targetResources: [
         testTargetResourceData.targetResources[0],
-        testTargetResourceData.targetResources[2]
-      ]
+        testTargetResourceData.targetResources[2],
+      ],
     };
 
     const storedData = sessionStorage.getItem('targetResources');
 
-    expect(storedData).toEqual(JSON.stringify(testTargetResourceDataAfterRemove));
-    expect(getByTestId(container, 'id-0')).toHaveTextContent(testTargetResourceDataAfterRemove.targetResources[0].id);
-    expect(getByTestId(container, 'resource-0')).toHaveTextContent(testTargetResourceDataAfterRemove.targetResources[0].name);
-    expect(getByTestId(container, 'id-1')).toHaveTextContent(testTargetResourceDataAfterRemove.targetResources[1].id);
-    expect(getByTestId(container, 'resource-1')).toHaveTextContent(testTargetResourceDataAfterRemove.targetResources[1].name);
+    expect(storedData).toEqual(
+      JSON.stringify(testTargetResourceDataAfterRemove)
+    );
+    expect(getByTestId(container, 'id-0')).toHaveTextContent(
+      testTargetResourceDataAfterRemove.targetResources[0].id
+    );
+    expect(getByTestId(container, 'resource-0')).toHaveTextContent(
+      testTargetResourceDataAfterRemove.targetResources[0].name
+    );
+    expect(getByTestId(container, 'id-1')).toHaveTextContent(
+      testTargetResourceDataAfterRemove.targetResources[1].id
+    );
+    expect(getByTestId(container, 'resource-1')).toHaveTextContent(
+      testTargetResourceDataAfterRemove.targetResources[1].name
+    );
   });
 });

--- a/src/pages/ResourceBatchUpdatePage.test.tsx
+++ b/src/pages/ResourceBatchUpdatePage.test.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { render, screen, waitFor, fireEvent, getByTestId } from '@testing-library/react';
+import { AppContext } from '../App-context';
+import ResourceBatchUpdatePage, {
+  ResourceBatchUpdatePageProps,
+} from './ResourceBatchUpdatePage';
+import api from '../common/utils/api/api';
+
+const testResourceBatchUpdatePagePros: ResourceBatchUpdatePageProps = {
+  mainResourceId: 'tprek:10',
+  targetResourcesString: 'tprek:11,tprek:12,tprek:13,tprek:14',
+}
+
+const testGetResourceResponse = {
+  "id":1010,
+  "name":{"fi":"test pk 10 fi", "sv":"test pk 10 sv", "en":"test pk 10 en"},
+  "origins":[
+    {"data_source":{"id":"tprek", "name":{"fi":"Toimipisterekisteri", "sv":null, "en":null}}, "origin_id":"10"},
+    {"data_source":{"id":"asti", "name":{"fi":null, "sv":null, "en":null}}, "origin_id":"110"}
+  ],
+}
+
+const testGetResourcesResponse = [
+  {
+    "id":1011,
+    "name":{"fi":"test pk 11 fi", "sv":"test pk 11 sv", "en":"test pk 11 en"},
+    "origins":[
+      {"data_source":{"id":"tprek", "name":{"fi":"Toimipisterekisteri", "sv":null, "en":null}}, "origin_id":"11"},
+      {"data_source":{"id":"asti", "name":{"fi":null, "sv":null, "en":null}}, "origin_id":"111"}
+    ],
+  },
+  {
+    "id":1012,
+    "name":{"fi":"test pk 12 fi", "sv":"test pk 12 sv", "en":"test pk 12 en"},
+    "origins":[
+      {"data_source":{"id":"tprek", "name":{"fi":"Toimipisterekisteri", "sv":null, "en":null}}, "origin_id":"12"},
+      {"data_source":{"id":"asti", "name":{"fi":null, "sv":null, "en":null}}, "origin_id":"112"}
+    ],
+  },
+  {
+    "id":1013,
+    "name":{"fi":"test pk 13 fi", "sv":"test pk 13 sv", "en":"test pk 13 en"},
+    "origins":[
+      {"data_source":{"id":"tprek", "name":{"fi":"Toimipisterekisteri", "sv":null, "en":null}}, "origin_id":"13"},
+      {"data_source":{"id":"asti", "name":{"fi":null, "sv":null, "en":null}}, "origin_id":"112"}
+    ],
+  }
+]
+
+const testTargetResourceData = {
+  "mainResourceId": 1010,
+  "mainResourceName": "test pk 10 fi",
+  "targetResources": [
+    {
+      "id": "tprek:11",
+      "name": "test pk 11 fi"
+    },
+    {
+      "id": "tprek:12",
+      "name": "test pk 12 fi"
+    },
+    {
+      "id": "tprek:13",
+      "name": "test pk 13 fi"
+    }
+  ]
+}
+
+const renderPage = () =>
+  render(
+    <Router>
+      <ResourceBatchUpdatePage
+        {...testResourceBatchUpdatePagePros}
+      />
+    </Router>
+  );
+
+
+describe(`<ResourceBatchUpdatePage />`, () => {
+  beforeEach(() => {
+    const sessionStorageMock = (() => {
+      let store = {};
+
+      return {
+        getItem: (key) => store[key] || null,
+        setItem: (key, value) => {
+          store[key] = value.toString();
+        },
+      };
+    })();
+
+    Object.defineProperty(window, 'sessionStorage', {
+      value: sessionStorageMock,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show loading indicator', async () => {
+    jest
+      .spyOn(api, 'getResource')
+      .mockImplementation(() => new Promise(() => {}));
+
+    renderPage();
+
+    await act(async () => {
+      expect(await screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Toimipisteiden tietojen haku'
+      );
+    });
+  });
+
+  it('should show error notification when api fails', async () => {
+    jest
+      .spyOn(api, 'getResource')
+      .mockImplementation(() =>
+        Promise.reject(new Error('Failed to load a resource'))
+      );
+
+    await act(async () => {renderPage()});
+
+    await act(async () => {
+      expect(await screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Virhe'
+      );
+
+      expect(
+        await screen.findByText('Toimipisteitä ei saatu ladattua.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should call get resource api correctly', async () => {
+    const apiGetResourceSpy = jest
+      .spyOn(api, 'getResource')
+      .mockImplementation(() => Promise.resolve(true));
+
+    renderPage();
+
+    await waitFor(async () => {
+      expect(apiGetResourceSpy).toHaveBeenCalledWith(
+        testResourceBatchUpdatePagePros.mainResourceId
+      );
+    });
+  });
+
+
+  it('should call get resources api correctly', async () => {
+    jest
+      .spyOn(api, 'getResource')
+      .mockImplementation(() => Promise.resolve(true));
+
+    const apiGetResourcesSpy = jest
+      .spyOn(api, 'getResources')
+      .mockImplementation(() => Promise.resolve(true));
+
+    renderPage();
+
+    await waitFor(async () => {
+      expect(apiGetResourcesSpy).toHaveBeenCalledWith(
+        testResourceBatchUpdatePagePros.targetResourcesString.split(',')
+      );
+    });
+  });
+
+  it('should write correct target resource data to session storage', async () => {
+    jest
+      .spyOn(api, 'getResource')
+      .mockImplementation(() => Promise.resolve(testGetResourceResponse));
+
+    jest
+      .spyOn(api, 'getResources')
+      .mockImplementation(() => Promise.resolve(testGetResourcesResponse));
+
+    await act(async () => {renderPage()});
+
+    const storedData = sessionStorage.getItem('targetResources');
+
+    expect(storedData).toEqual(JSON.stringify(testTargetResourceData));
+  });
+
+  it('should have correct items on resource list and session storage after remove', async () => {
+    jest
+      .spyOn(api, 'getResource')
+      .mockImplementation(() => Promise.resolve(testGetResourceResponse));
+
+    jest
+      .spyOn(api, 'getResources')
+      .mockImplementation(() => Promise.resolve(testGetResourcesResponse));
+
+    const { container } = renderPage();
+
+    await waitFor(() => {
+      expect(getByTestId(container, 'remove-1')).toBeInTheDocument();
+    });
+
+    const td = getByTestId(container, 'remove-1');
+    const removeButton = td.querySelector('button');
+    fireEvent.click(removeButton);
+
+    const testTargetResourceDataAfterRemove = {
+      ...testTargetResourceData,
+      targetResources: [
+        testTargetResourceData.targetResources[0],
+        testTargetResourceData.targetResources[2]
+      ]
+    };
+
+    const storedData = sessionStorage.getItem('targetResources');
+
+    expect(storedData).toEqual(JSON.stringify(testTargetResourceDataAfterRemove));
+    expect(getByTestId(container, 'id-0')).toHaveTextContent(testTargetResourceDataAfterRemove.targetResources[0].id);
+    expect(getByTestId(container, 'resource-0')).toHaveTextContent(testTargetResourceDataAfterRemove.targetResources[0].name);
+    expect(getByTestId(container, 'id-1')).toHaveTextContent(testTargetResourceDataAfterRemove.targetResources[1].id);
+    expect(getByTestId(container, 'resource-1')).toHaveTextContent(testTargetResourceDataAfterRemove.targetResources[1].name);
+  });
+});

--- a/src/pages/ResourceBatchUpdatePage.test.tsx
+++ b/src/pages/ResourceBatchUpdatePage.test.tsx
@@ -140,6 +140,22 @@ const testTargetResourceData: TargetResourcesProps = {
   ],
 };
 
+// same as testTargetResourceData, but second target resource removed
+const testTargetAfterRemove: TargetResourcesProps = {
+  mainResourceId: 1010,
+  mainResourceName: 'test pk 10 fi',
+  targetResources: [
+    {
+      id: 'tprek:11',
+      name: 'test pk 11 fi',
+    },
+    {
+      id: 'tprek:13',
+      name: 'test pk 13 fi',
+    },
+  ],
+};
+
 const renderPage = () =>
   render(
     <Router>
@@ -275,30 +291,20 @@ describe(`<ResourceBatchUpdatePage />`, () => {
     const removeButton = td.querySelector('button') as Element;
     fireEvent.click(removeButton);
 
-    const afterRemove = {
-      ...testTargetResourceData,
-      targetResources: [
-        testTargetResourceData.targetResources?.at(0),
-        testTargetResourceData.targetResources?.at(2),
-      ],
-    };
+    type TargetResource = { id: string; name: string };
+    const res0 = (
+      testTargetAfterRemove.targetResources as TargetResource[]
+    )[0] as TargetResource;
+    const res1 = (
+      testTargetAfterRemove.targetResources as TargetResource[]
+    )[1] as TargetResource;
 
-    const storedData = sessionStorage.getItem('targetResources');
-
-    expect(afterRemove.targetResources?.at(0)).toBeDefined();
-    expect(afterRemove.targetResources?.at(1)).toBeDefined();
-    expect(storedData).toEqual(JSON.stringify(afterRemove));
-    expect(getByTestId(container, 'id-0')).toHaveTextContent(
-      afterRemove.targetResources?.at(0)?.id || ''
+    expect(sessionStorage.getItem('targetResources')).toEqual(
+      JSON.stringify(testTargetAfterRemove)
     );
-    expect(getByTestId(container, 'resource-0')).toHaveTextContent(
-      afterRemove.targetResources?.at(0)?.name || ''
-    );
-    expect(getByTestId(container, 'id-1')).toHaveTextContent(
-      afterRemove.targetResources?.at(1)?.id || ''
-    );
-    expect(getByTestId(container, 'resource-1')).toHaveTextContent(
-      afterRemove.targetResources?.at(1)?.name || ''
-    );
+    expect(getByTestId(container, 'id-0')).toHaveTextContent(res0.id);
+    expect(getByTestId(container, 'resource-0')).toHaveTextContent(res0.name);
+    expect(getByTestId(container, 'id-1')).toHaveTextContent(res1.id);
+    expect(getByTestId(container, 'resource-1')).toHaveTextContent(res1.name);
   });
 });

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -25,7 +25,7 @@ export type ResourceBatchUpdatePageProps = {
 };
 
 // for some reason origins are not part of Resource type, this need to be fixed in API
-type ResourceWithOrigins = Resource & {
+export type ResourceWithOrigins = Resource & {
   origins: {
     origin_id: string;
     data_source: {

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -24,6 +24,21 @@ export type ResourceBatchUpdatePageProps = {
   targetResourcesString?: string;
 };
 
+// for some reason origins are not part of Resource type, this need to be fixed in API
+type ResourceWithOrigins = Resource & {
+  origins: {
+    origin_id: string;
+    data_source: {
+      id: string;
+      name: {
+        fi: string;
+        sv: string;
+        en: string;
+      };
+    };
+  }[];
+};
+
 const ResourceBatchUpdatePage = ({
   mainResourceId,
   targetResourcesString,
@@ -113,13 +128,14 @@ const ResourceBatchUpdatePage = ({
         api
           .getResources(targetResourceIDs)
           .then(async (resources: Resource[]) => {
-            // get id and name of resources if there is a match from origin
+            // for some reason origins are not part of Resource type, this need to be fixed in API
+            const resourcesWithOrigins = resources as ResourceWithOrigins[];
             const targetResources = targetResourceIDs
               .map((id) => ({
                 id,
-                resource: resources.find((res) =>
-                  (res as any).origins.some(
-                    (origin: any) =>
+                resource: resourcesWithOrigins.find((res) =>
+                  res.origins.some(
+                    (origin) =>
                       origin.data_source.id === id.split(':')[0] &&
                       origin.origin_id === id.split(':')[1]
                   )

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Notification,
+  Table,
+  Pagination,
+  RadioButton,
+  SelectionGroup,
+  IconTrash,
+} from 'hds-react';
+import {
+  PrimaryButton,
+  SecondaryButton,
+  SupplementaryButton,
+} from '../components/button/Button';
+import { useAppContext } from '../App-context';
+import api from '../common/utils/api/api';
+import { Language, Resource } from '../common/lib/types';
+import sessionStorage from '../common/utils/storage/sessionStorage';
+import './ResourceBatchUpdatePage.scss';
+import { TargetResourcesProps } from '../components/resource-opening-hours/ResourcePeriodsCopyFieldset';
+
+const onConfirm = () => {
+  console.log('onConfirm()');
+};
+const onClose = () => {
+  console.log('onClose()');
+};
+const onRemove = (id: string) => {
+  console.log('onRemove()', id);
+};
+
+const ResourceBatchUpdatePage = ({
+  id,
+  targetResourcesString,
+}: {
+  id: string;
+  targetResourcesString?: string;
+}): JSX.Element => {
+  const { language: contextLanguage } = useAppContext();
+  const language = contextLanguage || Language.FI;
+  const [resource, setResource] = useState<Resource | undefined>(undefined);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [isLoading, setLoading] = useState<boolean>(true);
+  const [targetResourceInfos, setTargetResourceInfos] = useState<Resource[]>(
+    []
+  );
+  const [pageIndex, setPageIndex] = useState(0);
+  const [selectedRadioItem, setSelectedRadioItem] = useState('copy');
+  const onChangeRadio = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedRadioItem(event.target.value);
+  };
+  const [targetResourceData, setTargetResourceData] = useState<
+    TargetResourcesProps | undefined
+  >(undefined);
+  const targetResourcesStorageKey = 'targetResources';
+
+  const cols = [
+    {
+      key: 'id',
+      headerName: 'ID',
+      isSortable: true,
+      transform: (item: { id: string }) => {
+        return <div style={{ textAlign: 'right' }}>{item.id}</div>;
+      },
+    },
+    { key: 'resource', headerName: 'Toimipiste', isSortable: true },
+    {
+      key: 'remove',
+      headerName: '',
+      transform: (item: { id: string }) => {
+        return (
+          <div style={{ textAlign: 'right', color: 'red' }}>
+            <SupplementaryButton size="small" onClick={() => onRemove(item.id)}>
+              <IconTrash size="xs" />
+            </SupplementaryButton>
+          </div>
+        );
+      },
+    },
+  ];
+  const rows = targetResourceInfos?.map((res) => ({
+    id: res.id,
+    resource: res?.name[language],
+    remove: 'x',
+  }));
+
+  useEffect(() => {
+    const fetchTargetResourceInfos = async (ids: string[]): Promise<void> => {
+      setLoading(true);
+      try {
+        const [resources] = await Promise.all([api.getResources(ids)]);
+        setTargetResourceInfos(resources);
+      } catch (e) {
+        setError(e as Error);
+      }
+      setLoading(false);
+    };
+    if (resource) {
+      if (targetResourcesString) {
+        const mainResourceId = resource.id;
+        const mainResourceName = resource?.name[language];
+        const targetResources = targetResourcesString.split(',');
+        const newData = { mainResourceId, mainResourceName, targetResources };
+        setTargetResourceData(newData);
+        sessionStorage.storeItem<TargetResourcesProps>({
+          key: targetResourcesStorageKey,
+          value: newData,
+        });
+        fetchTargetResourceInfos(targetResources);
+      } else {
+        const oldData = sessionStorage.getItem<TargetResourcesProps>(
+          targetResourcesStorageKey
+        );
+        if (oldData) {
+          if (oldData.mainResourceId === resource?.id) {
+            setTargetResourceData(oldData);
+          } else {
+            sessionStorage.removeItem(targetResourcesStorageKey);
+          }
+        }
+      }
+    }
+  }, [language, resource, targetResourcesString]);
+
+  useEffect((): void => {
+    api
+      .getResource(id)
+      .then(async (r: Resource) => {
+        setResource(r);
+        setLoading(false);
+      })
+      .catch((e: Error) => {
+        setError(e);
+        setLoading(false);
+      });
+  }, [id]);
+
+  if (error) {
+    return (
+      <>
+        <h1 className="resource-info-title">Virhe</h1>
+        <Notification label="Toimipistettä ei saatu ladattua." type="error">
+          Tarkista toimipiste-id.
+        </Notification>
+      </>
+    );
+  }
+
+  if (isLoading || !resource) {
+    return (
+      <>
+        <h1 className="resource-info-title">Toimipisteen tietojen haku</h1>
+      </>
+    );
+  }
+
+  const resourceCount = targetResourceInfos?.length || 0;
+  const pageSize = 10;
+  const pageCount = Math.ceil(resourceCount / pageSize);
+  const mainResourceName = targetResourceData?.mainResourceName;
+
+  return (
+    <div className="resource-batch-update-page">
+      <section className="section-title">
+        <h1>Joukkopäivitys</h1>
+        <div className="button-close">
+          <SecondaryButton size="small" onClick={onClose}>
+            Palaa etusivulle
+          </SecondaryButton>
+        </div>
+      </section>
+
+      <section className="section-spans">
+        <h2>Valitut aukiolot</h2>
+        <p>Olet valinnut joukkopäivitykseen alla olevat aukioloajat.</p>
+      </section>
+
+      <div className="section-resource-update">
+        <section className="section-resources">
+          <h2>Valitut toimipisteet</h2>
+          <p>
+            Olet valinnut {resourceCount} toimipistettä joukkopäivitykseen. Alta
+            näet valitsemasi toimipisteet ja voit tarvittaessa poistaa
+            yksittäisiä toimipisteitä listalta.
+          </p>
+          {rows && (
+            <Table
+              cols={cols}
+              rows={rows.slice(
+                pageIndex * pageSize,
+                (pageIndex + 1) * pageSize
+              )}
+              variant="light"
+              indexKey="id"
+              renderIndexCol
+            />
+          )}
+          <Pagination
+            language="en"
+            onChange={(event, index) => {
+              event.preventDefault();
+              setPageIndex(index);
+              console.log('Pagination setPageIndex', index);
+            }}
+            pageCount={pageCount}
+            pageHref={() => '#'}
+            pageIndex={pageIndex}
+            paginationAriaLabel="Pagination"
+            siblingCount={2}
+          />
+        </section>
+
+        <section className="section-update">
+          <h2>Päivitä aukioloajat</h2>
+          <div>
+            Voit valita seuraavat toimet:
+            <ul className="list-options">
+              <li>
+                Korvaa valittujen toimipisteiden aukiolotiedot. Tämä päivittää
+                tiedot vastaamaan toimipisteen {`${mainResourceName} `}
+                aukiolotietoja.
+              </li>
+              <li>
+                Kopioi ja lisää aukiolotiedot valittuihin toimipisteisiin. Tämä
+                lisää uudet tiedot ilman, että olemassaolevia aukiolotietoja
+                muutetaan.
+              </li>
+            </ul>
+          </div>
+          <SelectionGroup label="Valitse toiminto">
+            <RadioButton
+              id="radio-update"
+              name="radio-update"
+              value="update"
+              label="Korvaa aukioloajat"
+              checked={selectedRadioItem === 'update'}
+              onChange={onChangeRadio}
+            />
+            <RadioButton
+              id="radio-copy"
+              name="radio-copy"
+              value="copy"
+              label="Kopioi ja lisää aukioloajat"
+              checked={selectedRadioItem === 'copy'}
+              onChange={onChangeRadio}
+            />
+          </SelectionGroup>
+          <div className="button-confirm">
+            <PrimaryButton onClick={onConfirm}>Vahvista</PrimaryButton>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default ResourceBatchUpdatePage;

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -44,7 +44,6 @@ const ResourceBatchUpdatePage = ({
   targetResourcesString,
 }: ResourceBatchUpdatePageProps): JSX.Element => {
   const { language: contextLanguage } = useAppContext();
-  const language = contextLanguage || Language.FI;
   const [resource, setResource] = useState<Resource | undefined>(undefined);
   const [error, setError] = useState<Error | undefined>(undefined);
   const [isLoading, setLoading] = useState<boolean>(true);
@@ -53,15 +52,25 @@ const ResourceBatchUpdatePage = ({
   const [targetResourceData, setTargetResourceData] = useState<
     TargetResourcesProps | undefined
   >(undefined);
+
+  // page constants
+  const pageSize = 10;
+  const resourceCount = targetResourceData?.targetResources?.length || 0;
+  const pageCount = Math.ceil(resourceCount / pageSize);
+  const mainResourceName = targetResourceData?.mainResourceName;
+  const language = contextLanguage || Language.FI;
   const targetResourcesStorageKey = 'targetResources';
 
+  // event functions
   const onChangeRadio = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSelectedRadioItem(event.target.value);
   };
   const onConfirm = () => {
+    // TODO: will be implemented later
     console.log('onConfirm()');
   };
   const onClose = () => {
+    // TODO: will be implemented later
     console.log('onClose()');
   };
   const onRemove = (id: string) => {
@@ -80,6 +89,7 @@ const ResourceBatchUpdatePage = ({
     }
   };
 
+  // table definition
   const cols = [
     {
       key: 'id',
@@ -110,7 +120,6 @@ const ResourceBatchUpdatePage = ({
       },
     },
   ];
-
   const rows = targetResourceData?.targetResources?.map((res) => {
     return {
       id: res.id,
@@ -169,12 +178,10 @@ const ResourceBatchUpdatePage = ({
         const oldData = sessionStorage.getItem<TargetResourcesProps>(
           targetResourcesStorageKey
         );
-        if (oldData) {
-          if (oldData.mainResourceId === resource?.id) {
-            setTargetResourceData(oldData);
-          } else {
-            sessionStorage.removeItem(targetResourcesStorageKey);
-          }
+        if (oldData && oldData.mainResourceId === resource?.id) {
+          setTargetResourceData(oldData);
+        } else {
+          sessionStorage.removeItem(targetResourcesStorageKey);
         }
       }
     }
@@ -214,11 +221,6 @@ const ResourceBatchUpdatePage = ({
     );
   }
 
-  const resourceCount = targetResourceData?.targetResources?.length || 0;
-  const pageSize = 10;
-  const pageCount = Math.ceil(resourceCount / pageSize);
-  const mainResourceName = targetResourceData?.mainResourceName;
-
   return (
     <div className="resource-batch-update-page">
       <section className="section-title">
@@ -233,6 +235,7 @@ const ResourceBatchUpdatePage = ({
       <section className="section-spans">
         <h2>Valitut aukiolot</h2>
         <p>Olet valinnut joukkopäivitykseen alla olevat aukioloajat.</p>
+        {/* this block will be implemented later */}
       </section>
 
       <div className="section-resource-update">

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -19,13 +19,15 @@ import sessionStorage from '../common/utils/storage/sessionStorage';
 import './ResourceBatchUpdatePage.scss';
 import { TargetResourcesProps } from '../components/resource-opening-hours/ResourcePeriodsCopyFieldset';
 
+export type ResourceBatchUpdatePageProps = {
+  mainResourceId: string;
+  targetResourcesString?: string;
+};
+
 const ResourceBatchUpdatePage = ({
   mainResourceId,
   targetResourcesString,
-}: {
-  mainResourceId: string;
-  targetResourcesString?: string;
-}): JSX.Element => {
+}: ResourceBatchUpdatePageProps): JSX.Element => {
   const { language: contextLanguage } = useAppContext();
   const language = contextLanguage || Language.FI;
   const [resource, setResource] = useState<Resource | undefined>(undefined);
@@ -188,7 +190,7 @@ const ResourceBatchUpdatePage = ({
     );
   }
 
-  if (isLoading || !resource) {
+  if (isLoading || !resource || !targetResourceData) {
     return (
       <>
         <h1 className="resource-info-title">Toimipisteiden tietojen haku</h1>

--- a/src/pages/ResourcePage.test.tsx
+++ b/src/pages/ResourcePage.test.tsx
@@ -156,7 +156,7 @@ describe(`<ResourcePage />`, () => {
 
     render(
       <Router>
-        <ResourcePage id="tprek:8100" />
+        <ResourcePage mainResourceId="tprek:8100" />
       </Router>
     );
 
@@ -177,7 +177,7 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       render(
         <Router>
-          <ResourcePage id="tprek:8100" />
+          <ResourcePage mainResourceId="tprek:8100" />
         </Router>
       );
     });
@@ -197,7 +197,7 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       render(
         <Router>
-          <ResourcePage id="tprek:8100" />
+          <ResourcePage mainResourceId="tprek:8100" />
         </Router>
       );
     });
@@ -214,7 +214,7 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       container = render(
         <Router>
-          <ResourcePage id="tprek:8100" />
+          <ResourcePage mainResourceId="tprek:8100" />
         </Router>
       ).container;
     });
@@ -239,7 +239,7 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       container = render(
         <Router>
-          <ResourcePage id="tprek:8100" />
+          <ResourcePage mainResourceId="tprek:8100" />
         </Router>
       ).container;
     });
@@ -255,7 +255,7 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       render(
         <Router>
-          <ResourcePage id="tprek:8100" />
+          <ResourcePage mainResourceId="tprek:8100" />
         </Router>
       );
     });

--- a/src/pages/ResourcePage.tsx
+++ b/src/pages/ResourcePage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useEffect, useState } from 'react';
-import { Accordion, Notification } from 'hds-react';
+import { Accordion, Notification, IconArrowRight } from 'hds-react';
 import { useAppContext } from '../App-context';
 import api from '../common/utils/api/api';
 import { Language, Resource } from '../common/lib/types';
@@ -13,6 +13,8 @@ import ResourcePeriodsCopyFieldset, {
 } from '../components/resource-opening-hours/ResourcePeriodsCopyFieldset';
 import './ResourcePage.scss';
 import ResourceTitle from '../components/resource-title/ResourceTitle';
+import { SecondaryButton } from '../components/button/Button';
+import useGoToResourceBatchUpdatePage from '../hooks/useGoToResourceBatchUpdatePage';
 
 const ResourceSection = ({
   id,
@@ -62,6 +64,7 @@ const ResourcePage = ({
     TargetResourcesProps | undefined
   >(undefined);
   const targetResourcesStorageKey = 'targetResources';
+  const goToResourceBatchUpdatePage = useGoToResourceBatchUpdatePage();
 
   const hasTargetResources =
     targetResourceData?.mainResourceId === resource?.id &&
@@ -150,6 +153,13 @@ const ResourcePage = ({
           Tällä toimipisteellä on {childResources.length} alakohdetta. Niiden
           aukioloajat löytyvät alempana tällä sivulla.
         </p>
+      )}
+      {hasTargetResources && (
+        <SecondaryButton
+          iconRight={<IconArrowRight aria-hidden />}
+          onClick={goToResourceBatchUpdatePage}>
+          Jatka joukkopäivitykseen
+        </SecondaryButton>
       )}
       {hasTargetResources && (
         <ResourcePeriodsCopyFieldset

--- a/src/pages/ResourcePage.tsx
+++ b/src/pages/ResourcePage.tsx
@@ -46,11 +46,11 @@ const ResourceDetailsSection = ({
 
 const ResourcePage = ({
   childId,
-  id,
+  mainResourceId,
   targetResourcesString,
 }: {
   childId?: string;
-  id: string;
+  mainResourceId: string;
   targetResourcesString?: string;
 }): JSX.Element => {
   const { language: contextLanguage } = useAppContext();
@@ -74,10 +74,15 @@ const ResourcePage = ({
   useEffect(() => {
     if (resource) {
       if (targetResourcesString) {
-        const mainResourceId = resource.id;
-        const mainResourceName = resource?.name[language];
-        const targetResources = targetResourcesString.split(',');
-        const newData = { mainResourceId, mainResourceName, targetResources };
+        const targetResourceIDs = targetResourcesString.split(',');
+        const newData = {
+          mainResourceId: resource.id,
+          mainResourceName: resource?.name[language],
+          targetResources: targetResourceIDs.map((id) => ({
+            id,
+            name: '',
+          })),
+        };
         setTargetResourceData(newData);
         sessionStorage.storeItem<TargetResourcesProps>({
           key: targetResourcesStorageKey,
@@ -102,7 +107,7 @@ const ResourcePage = ({
     // UseEffect's callbacks are synchronous to prevent a race condition.
     // We can not use an async function as an useEffect's callback because it would return Promise<void>
     api
-      .getResource(id)
+      .getResource(mainResourceId)
       .then(async (r: Resource) => {
         setResource(r);
         const resourceHasChildren = r.children.length > 0;
@@ -124,7 +129,7 @@ const ResourcePage = ({
         setError(e);
         setLoading(false);
       });
-  }, [id]);
+  }, [mainResourceId]);
 
   if (error) {
     return (

--- a/src/services/holidays.test.ts
+++ b/src/services/holidays.test.ts
@@ -197,62 +197,6 @@ describe('holidays', () => {
               "sv": "Nyårsafton",
             },
           },
-          Object {
-            "date": "2024-01-01",
-            "name": Object {
-              "en": "New Year's Day",
-              "fi": "Uudenvuodenpäivä",
-              "sv": "Nyårsdagen",
-            },
-          },
-          Object {
-            "date": "2024-01-06",
-            "name": Object {
-              "en": "Epiphany",
-              "fi": "Loppiainen",
-              "sv": "Trettondedag jul",
-            },
-          },
-          Object {
-            "date": "2024-03-28",
-            "name": Object {
-              "en": "Maundy Thursday",
-              "fi": "Kiirastorstai",
-              "sv": "Skärtorsdagen",
-            },
-          },
-          Object {
-            "date": "2024-03-29",
-            "name": Object {
-              "en": "Good Friday",
-              "fi": "Pitkäperjantai",
-              "sv": "Långfredagen",
-            },
-          },
-          Object {
-            "date": "2024-03-30",
-            "name": Object {
-              "en": "Easter Saturday",
-              "fi": "Pääsiäislauantai",
-              "sv": "Påsklördag",
-            },
-          },
-          Object {
-            "date": "2024-03-31",
-            "name": Object {
-              "en": "Easter Sunday",
-              "fi": "Pääsiäispäivä",
-              "sv": "Påskdagen",
-            },
-          },
-          Object {
-            "date": "2024-04-01",
-            "name": Object {
-              "en": "Easter Monday",
-              "fi": "2. pääsiäispäivä",
-              "sv": "Annandag påsk",
-            },
-          },
         ]
       `);
       expect(getHolidays(new Date('2024-01-01'))).toMatchInlineSnapshot(`
@@ -449,22 +393,6 @@ describe('holidays', () => {
               "sv": "Nyårsafton",
             },
           },
-          Object {
-            "date": "2025-01-01",
-            "name": Object {
-              "en": "New Year's Day",
-              "fi": "Uudenvuodenpäivä",
-              "sv": "Nyårsdagen",
-            },
-          },
-          Object {
-            "date": "2025-01-06",
-            "name": Object {
-              "en": "Epiphany",
-              "fi": "Loppiainen",
-              "sv": "Trettondedag jul",
-            },
-          },
         ]
       `);
       expect(getHolidays(new Date('2025-01-01'))).toMatchInlineSnapshot(`
@@ -659,46 +587,6 @@ describe('holidays', () => {
               "en": "New Year's Eve",
               "fi": "Uudenvuodenaatto",
               "sv": "Nyårsafton",
-            },
-          },
-          Object {
-            "date": "2026-01-01",
-            "name": Object {
-              "en": "New Year's Day",
-              "fi": "Uudenvuodenpäivä",
-              "sv": "Nyårsdagen",
-            },
-          },
-          Object {
-            "date": "2026-01-06",
-            "name": Object {
-              "en": "Epiphany",
-              "fi": "Loppiainen",
-              "sv": "Trettondedag jul",
-            },
-          },
-          Object {
-            "date": "2026-04-02",
-            "name": Object {
-              "en": "Maundy Thursday",
-              "fi": "Kiirastorstai",
-              "sv": "Skärtorsdagen",
-            },
-          },
-          Object {
-            "date": "2026-04-03",
-            "name": Object {
-              "en": "Good Friday",
-              "fi": "Pitkäperjantai",
-              "sv": "Långfredagen",
-            },
-          },
-          Object {
-            "date": "2026-04-04",
-            "name": Object {
-              "en": "Easter Saturday",
-              "fi": "Pääsiäislauantai",
-              "sv": "Påsklördag",
             },
           },
         ]

--- a/src/services/holidays.ts
+++ b/src/services/holidays.ts
@@ -90,9 +90,10 @@ export const isHoliday = (holiday: Holiday): boolean =>
 
 export const getHolidays = (now: Date | undefined = new Date()): Holiday[] => {
   const currentYear = now.getFullYear();
-  const later = new Date();
+  const later = new Date(now);
   const nextYear = currentYear + 1;
   later.setFullYear(nextYear);
+  later.setDate(later.getDate() - 1);
   const start = formatDate(now);
   const end = formatDate(later);
 


### PR DESCRIPTION
## Description
- Created batch update resource page view
- This PR contains basics of the view and remove resource functionality (There will be some more features coming in next PRs)
- Tests for the view

## Related Issue
- Jira ticket of the view [HAUKI-574](https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-574)
- Jira ticket of remove resources from the view [HAUKI-579](https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-579)
- [UI Design](https://www.figma.com/file/o9KFjflfk5WiY4Djsg91Vn/HAUKI-small-developments?type=design&node-id=32-16625&mode=design&t=STXL4fepfm7wIkKx-0) 

## How Has This Been Tested?
- Tested running on local machine.
- Unit tests pass

## Known issues
- Table is now paginated with 10 resource pages (which can be changed if it feels wrong)
- api.GetResources returns resources in different type than `Resource[]` so I'm not sure in which end this should be fixed, probably in API. I extended type of `Resource` with origins to make it match with api output (until API is fixed)

[HAUKI-574]: https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HAUKI-579]: https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ