### PR TITLE
Hauki 576 & 581 apply batch resource copy or overwrite

### DIFF
--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -361,12 +361,13 @@ export default {
 
   copyDatePeriods: async (
     resourceId: number,
-    targetResources: string[]
+    targetResources: string[],
+    replace: boolean
   ): Promise<boolean> => {
     const permission = await apiPost<PermissionResponse>({
       path: `${resourceBasePath}/${resourceId}/copy_date_periods`,
       parameters: {
-        replace: true,
+        replace,
         target_resources: targetResources.join(','),
       },
     });

--- a/src/components/modal/NotificationModal.tsx
+++ b/src/components/modal/NotificationModal.tsx
@@ -1,0 +1,59 @@
+import React, { ReactNode, useState } from 'react';
+import { Dialog, IconInfoCircle } from 'hds-react';
+import { PrimaryButton } from '../button/Button';
+
+type UseModalProps = {
+  isModalOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+};
+
+export const useModal = (): UseModalProps => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const openModal = (): void => setIsModalOpen(true);
+  const closeModal = (): void => setIsModalOpen(false);
+  return {
+    isModalOpen,
+    openModal,
+    closeModal,
+  };
+};
+
+export function NotificationModal({
+  buttonText,
+  isLoading,
+  loadingText,
+  isOpen,
+  onClose,
+  text,
+  title,
+}: {
+  buttonText: string;
+  isLoading?: boolean;
+  loadingText?: string;
+  isOpen: boolean;
+  onClose: () => void;
+  text: string | ReactNode;
+  title: string;
+}): JSX.Element | null {
+  const titleId = 'notification-modal-title';
+
+  return (
+    <Dialog aria-labelledby={titleId} id="notification-modal" isOpen={isOpen}>
+      <Dialog.Header
+        id={titleId}
+        title={title}
+        iconLeft={<IconInfoCircle aria-hidden="true" />}
+      />
+      <Dialog.Content>{text}</Dialog.Content>
+      <Dialog.ActionButtons>
+        <PrimaryButton
+          isLoading={isLoading}
+          loadingText={loadingText}
+          onClick={onClose}>
+          {buttonText}
+        </PrimaryButton>
+      </Dialog.ActionButtons>
+    </Dialog>
+  );
+}

--- a/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.test.tsx
+++ b/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.test.tsx
@@ -54,7 +54,8 @@ describe(`<ResourcePeriodsCopyFieldset/>`, () => {
     await waitFor(async () => {
       expect(apiCopySpy).toHaveBeenCalledWith(
         testCopyResourceData.mainResourceId,
-        testCopyResourceData.targetResources?.map((resource) => resource.id)
+        testCopyResourceData.targetResources?.map((resource) => resource.id),
+        true
       );
       expect(toastSuccessSpy).toHaveBeenCalled();
       expect(onChange).toHaveBeenCalledWith({

--- a/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.tsx
+++ b/src/components/resource-opening-hours/ResourcePeriodsCopyFieldset.tsx
@@ -38,7 +38,8 @@ const ResourcePeriodsCopyFieldset = ({
     try {
       await api.copyDatePeriods(
         mainResourceId,
-        targetResources.map((item) => item.id)
+        targetResources.map((item) => item.id),
+        true
       );
       toast.success({
         dataTestId: 'period-copy-success',

--- a/src/pages/ResourceBatchUpdatePage.scss
+++ b/src/pages/ResourceBatchUpdatePage.scss
@@ -39,9 +39,16 @@
 
   .section-resource-update {
     display: flex;
+    flex-direction: column;
     gap: $spacing-layout-xs;
     background-color: transparent;
     align-items: flex-start;
+  }
+
+  @media screen and (min-width: $breakpoint-m) {
+    .section-resource-update {
+      flex-direction: row;
+    }
   }
 
   .button-confirm {

--- a/src/pages/ResourceBatchUpdatePage.test.tsx
+++ b/src/pages/ResourceBatchUpdatePage.test.tsx
@@ -126,6 +126,10 @@ const testTargetResourceData: TargetResourcesProps = {
   mainResourceName: 'test pk 10 fi',
   targetResources: [
     {
+      id: 'tprek:10',
+      name: 'test pk 10 fi',
+    },
+    {
       id: 'tprek:11',
       name: 'test pk 11 fi',
     },
@@ -146,8 +150,12 @@ const testTargetAfterRemove: TargetResourcesProps = {
   mainResourceName: 'test pk 10 fi',
   targetResources: [
     {
-      id: 'tprek:11',
-      name: 'test pk 11 fi',
+      id: 'tprek:10',
+      name: 'test pk 10 fi',
+    },
+    {
+      id: 'tprek:12',
+      name: 'test pk 12 fi',
     },
     {
       id: 'tprek:13',

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -136,8 +136,11 @@ const ResourceBatchUpdatePage = ({
 
         const handleApiResponse = async (resources: Resource[]) => {
           // for some reason origins are not part of Resource type, this need to be fixed in API
-          const resourcesWithOrigins = resources as ResourceWithOrigins[];
-          const targetResources = targetResourceIDs
+          const resourcesWithOrigins = [
+            resource,
+            ...resources,
+          ] as ResourceWithOrigins[];
+          const targetResources = [mainResourceId, ...targetResourceIDs]
             .map((id) => ({
               id,
               resource: resourcesWithOrigins.find((res) =>
@@ -187,7 +190,7 @@ const ResourceBatchUpdatePage = ({
         }
       }
     }
-  }, [language, resource, targetResourcesString]);
+  }, [language, resource, targetResourcesString, mainResourceId]);
 
   // get main resource
   useEffect((): void => {

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -96,9 +96,6 @@ const ResourceBatchUpdatePage = ({
         key: 'id',
         headerName: 'ID',
         isSortable: true,
-        transform: (item: { id: string }) => {
-          return <div style={{ textAlign: 'right' }}>{item.id}</div>;
-        },
       },
       { key: 'resource', headerName: 'Toimipiste', isSortable: true },
       {


### PR DESCRIPTION
## Changes in this PR
- NotificationModal for final confirmation
- Logic for closing browser tab and loging out
- Toast notifications for errors
- Toast notification for successful resource remove
- Some fixes to css
- Show main resource also in resource list table
- Call API to do the final operation

## Related Issue
- Jira ticket of resource overwrite [HAUKI-576](https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-576)
- Jira ticket of resource copy [HAUKI-581](https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-581)
- [UI Design](https://www.figma.com/file/o9KFjflfk5WiY4Djsg91Vn/HAUKI-small-developments?type=design&node-id=32-16625&mode=design&t=STXL4fepfm7wIkKx-0) 

## How Has This Been Tested?
- Tested running on local machine.
- Unit tests pass


[HAUKI-576]: https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HAUKI-581]: https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ