### PR TITLE
fix: HAUKI-486 navigation menu link color important

### DIFF
--- a/src/components/header/HaukiHeader.scss
+++ b/src/components/header/HaukiHeader.scss
@@ -1,7 +1,7 @@
 @import '~hds-design-tokens/lib/all.scss';
 
 .header {
-  --nav-link-font-color: var(--color-black-90);
+  --nav-link-font-color: var(--color-black-90) !important;
 
   @media screen and (max-width: $breakpoint-l) {
     --lang-selector-item-font-color: var(--color-black-90) !important;


### PR DESCRIPTION
# Fixing navigation menu link color override

When running the app in container, link color override is not applying correctly. Fixing by adding `!important`

<img width="522" alt="Screenshot 2023-11-07 at 9 44 18" src="https://github.com/City-of-Helsinki/hauki-admin-ui/assets/66477579/8cfd41e3-1ba2-4446-83b9-34d7fc958e02">
<img width="488" alt="Screenshot 2023-11-07 at 9 44 23" src="https://github.com/City-of-Helsinki/hauki-admin-ui/assets/66477579/d1a5f332-714d-429a-91c5-f891db2dec33">
