### PR TITLE
Hauki 595 text changes and loading spinner changes

### DIFF
--- a/src/pages/ResourceBatchUpdatePage.test.tsx
+++ b/src/pages/ResourceBatchUpdatePage.test.tsx
@@ -126,10 +126,6 @@ const testTargetResourceData: TargetResourcesProps = {
   mainResourceName: 'test pk 10 fi',
   targetResources: [
     {
-      id: 'tprek:10',
-      name: 'test pk 10 fi',
-    },
-    {
       id: 'tprek:11',
       name: 'test pk 11 fi',
     },
@@ -150,12 +146,8 @@ const testTargetAfterRemove: TargetResourcesProps = {
   mainResourceName: 'test pk 10 fi',
   targetResources: [
     {
-      id: 'tprek:10',
-      name: 'test pk 10 fi',
-    },
-    {
-      id: 'tprek:12',
-      name: 'test pk 12 fi',
+      id: 'tprek:11',
+      name: 'test pk 11 fi',
     },
     {
       id: 'tprek:13',

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -309,7 +309,7 @@ const ResourceBatchUpdatePage = ({
   return (
     <div className="resource-batch-update-page">
       <section className="section-title">
-        <h1>Joukkopäivitys</h1>
+        <h1>{mainResourceName}</h1>
         <div className="button-close">
           <SecondaryButton size="small" onClick={onClose}>
             Palaa etusivulle
@@ -318,7 +318,7 @@ const ResourceBatchUpdatePage = ({
       </section>
 
       <section className="section-spans">
-        <h2>Valitut aukiolot</h2>
+        <h2>Joukkopäivitykseen valitut aukiolot</h2>
         <p>Olet valinnut joukkopäivitykseen alla olevat aukioloajat.</p>
         {/* this block will be implemented later */}
       </section>

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -123,7 +123,6 @@ const ResourceBatchUpdatePage = ({
     }
 
     setLoading(true);
-    openModal();
     api
       .copyDatePeriods(
         resource?.id || 0,
@@ -134,6 +133,7 @@ const ResourceBatchUpdatePage = ({
       )
       .then(async () => {
         setLoading(false);
+        openModal();
       })
       .catch((e: Error) => {
         setLoading(false);
@@ -406,7 +406,12 @@ const ResourceBatchUpdatePage = ({
             />
           </SelectionGroup>
           <div className="button-confirm">
-            <PrimaryButton onClick={onConfirm}>Vahvista</PrimaryButton>
+            <PrimaryButton
+              onClick={onConfirm}
+              loadingText="Päivitetään aukiolotietoja"
+              isLoading={isLoading}>
+              Vahvista
+            </PrimaryButton>
           </div>
         </section>
       </div>
@@ -421,8 +426,6 @@ const ResourceBatchUpdatePage = ({
           </span>
         }
         buttonText="Sulje aukiolosovellus"
-        loadingText="Päivitetään aukiolotietoja"
-        isLoading={isLoading}
         isOpen={isModalOpen}
         onClose={onClose}
       />

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -209,11 +209,8 @@ const ResourceBatchUpdatePage = ({
 
         const handleApiResponse = async (resources: Resource[]) => {
           // for some reason origins are not part of Resource type, this need to be fixed in API
-          const resourcesWithOrigins = [
-            resource,
-            ...resources,
-          ] as ResourceWithOrigins[];
-          const targetResources = [mainResourceId, ...targetResourceIDs]
+          const resourcesWithOrigins = resources as ResourceWithOrigins[];
+          const targetResources = targetResourceIDs
             .map((id) => ({
               id,
               resource: resourcesWithOrigins.find((res) =>
@@ -267,7 +264,7 @@ const ResourceBatchUpdatePage = ({
         }
       }
     }
-  }, [language, resource, targetResourcesString, mainResourceId]);
+  }, [language, resource, targetResourcesString]);
 
   // get main resource
   useEffect((): void => {

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -203,6 +203,8 @@ const ResourceBatchUpdatePage = ({
 
   // get data of target resources
   useEffect(() => {
+    let isMounted = true;
+
     if (resource) {
       if (targetResourcesString) {
         const targetResourceIDs = targetResourcesString.split(',');
@@ -233,12 +235,14 @@ const ResourceBatchUpdatePage = ({
             targetResources,
           };
 
-          setTargetResourceData(newData);
           sessionStorage.storeItem<TargetResourcesProps>({
             key: targetResourcesStorageKey,
             value: newData,
           });
-          setLoading(false);
+          if (isMounted) {
+            setTargetResourceData(newData);
+            setLoading(false);
+          }
         };
 
         // fetch target resource data from api
@@ -264,16 +268,24 @@ const ResourceBatchUpdatePage = ({
         }
       }
     }
+
+    return () => {
+      isMounted = false;
+    };
   }, [language, resource, targetResourcesString]);
 
   // get main resource
-  useEffect((): void => {
+  useEffect(() => {
+    let isMounted = true;
+
     setLoading(true);
     api
       .getResource(mainResourceId)
       .then(async (r: Resource) => {
-        setResource(r);
-        setLoading(false);
+        if (isMounted) {
+          setResource(r);
+          setLoading(false);
+        }
       })
       .catch((e: Error) => {
         setLoading(false);
@@ -282,6 +294,10 @@ const ResourceBatchUpdatePage = ({
           `Toimipisteen tietoja ei saatu ladattua. Virhe: ${e}`
         );
       });
+
+    return () => {
+      isMounted = false;
+    };
   }, [mainResourceId]);
 
   if (error) {

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -25,6 +25,7 @@ import { Language, Resource } from '../common/lib/types';
 import sessionStorage from '../common/utils/storage/sessionStorage';
 import './ResourceBatchUpdatePage.scss';
 import { TargetResourcesProps } from '../components/resource-opening-hours/ResourcePeriodsCopyFieldset';
+import useReturnToResourcePage from '../hooks/useReturnToResourcePage';
 
 export type ResourceBatchUpdatePageProps = {
   mainResourceId: string;
@@ -68,6 +69,7 @@ const ResourceBatchUpdatePage = ({
   const [targetResourceData, setTargetResourceData] = useState<
     TargetResourcesProps | undefined
   >(undefined);
+  const ReturnToResourcePage = useReturnToResourcePage();
 
   // page constants
   const pageSize = 10;
@@ -324,7 +326,7 @@ const ResourceBatchUpdatePage = ({
       <section className="section-title">
         <h1>{mainResourceName}</h1>
         <div className="button-close">
-          <SecondaryButton size="small" onClick={onClose}>
+          <SecondaryButton size="small" onClick={ReturnToResourcePage}>
             Palaa etusivulle
           </SecondaryButton>
         </div>


### PR DESCRIPTION
Fixed a list of small issues clearly described in [Jira Ticket HAUKI-595](https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-595)

Fixed also:
- Don't show main resource on target list
- Annoying memory leak warnings on console and in tests. 
  - The problem was calling state changing functions inside of async callback. So the component could have been unmounted already before async callback is called.  -> I just made a boolean `isMounted` to check the status