### PR TITLE
Fix buggy async callbacks

### DIFF
--- a/src/components/opening-period-accordion/OpeningPeriodAccordion.tsx
+++ b/src/components/opening-period-accordion/OpeningPeriodAccordion.tsx
@@ -201,11 +201,11 @@ const OpeningPeriodAccordion = ({
           </button>
         </div>
         <ConfirmationModal
-          onConfirm={async (): Promise<void> => {
+          onConfirm={() => {
             if (onDelete) {
               setDeleting(true);
               try {
-                await onDelete();
+                onDelete();
                 setDeleting(false);
                 toast.success({
                   label: `Aukiolo "${periodName}" poistettu onnistuneesti.`,

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -212,6 +212,8 @@ const ResourceBatchUpdatePage = ({
         const targetResourceIDs = targetResourcesString.split(',');
 
         const handleApiResponse = async (resources: Resource[]) => {
+          if (!isMounted) return;
+
           // for some reason origins are not part of Resource type, this need to be fixed in API
           const resourcesWithOrigins = resources as ResourceWithOrigins[];
           const targetResources = targetResourceIDs
@@ -241,10 +243,8 @@ const ResourceBatchUpdatePage = ({
             key: targetResourcesStorageKey,
             value: newData,
           });
-          if (isMounted) {
-            setTargetResourceData(newData);
-            setLoading(false);
-          }
+          setTargetResourceData(newData);
+          setLoading(false);
         };
 
         // fetch target resource data from api
@@ -284,10 +284,10 @@ const ResourceBatchUpdatePage = ({
     api
       .getResource(mainResourceId)
       .then(async (r: Resource) => {
-        if (isMounted) {
-          setResource(r);
-          setLoading(false);
-        }
+        if (!isMounted) return;
+
+        setResource(r);
+        setLoading(false);
       })
       .catch((e: Error) => {
         setLoading(false);

--- a/src/pages/ResourcePage.tsx
+++ b/src/pages/ResourcePage.tsx
@@ -103,12 +103,16 @@ const ResourcePage = ({
     }
   }, [language, resource, targetResourcesString]);
 
-  useEffect((): void => {
+  useEffect(() => {
+    let isMounted = true;
+
     // UseEffect's callbacks are synchronous to prevent a race condition.
     // We can not use an async function as an useEffect's callback because it would return Promise<void>
     api
       .getResource(mainResourceId)
       .then(async (r: Resource) => {
+        if (!isMounted) return;
+
         setResource(r);
         const resourceHasChildren = r.children.length > 0;
         const resourceHasParents = r.parents.length > 0;
@@ -129,6 +133,10 @@ const ResourcePage = ({
         setError(e);
         setLoading(false);
       });
+
+    return () => {
+      isMounted = false;
+    };
   }, [mainResourceId]);
 
   if (error) {


### PR DESCRIPTION
I previously fixed some buggy async callbacks on [PR357](https://github.com/City-of-Helsinki/hauki-admin-ui/pull/357). I still found one to fix on `OpeningPrediodAccordion.tsx`... but this time it made more sense to just change it as syncronous.

Also made previous fixes little bit cleaner.