### PR TITLE
HAUKI-575-date-period-copy-selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.envrc
 .idea
 
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@sentry/react": "^6.19.7",
     "@sentry/tracing": "^6.16.1",
     "@testing-library/react": "^11.0.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^12.2.2",
     "@types/cypress": "^1.1.3",
     "@types/cypress-axe": "^0.11.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import EditNormalOpeningHoursPage from './pages/EditNormalOpeningHoursPage';
 import EditHolidaysPage from './pages/EditHolidaysPage';
 import AddExceptionOpeningHoursPage from './pages/AddExceptionOpeningHoursPage';
 import EditExceptionOpeningHoursPage from './pages/EditExceptionOpeningHoursPage';
+import { SelectedDatePeriodsProvider } from './common/selectedDatePeriodsContext/SelectedDatePeriodsContext';
 
 type OptionalAuthTokens = AuthTokens | undefined;
 
@@ -142,11 +143,13 @@ const App = (): JSX.Element => {
                     id && (
                       <NavigationAndFooterWrapper>
                         <Main id="main">
-                          <ResourcePage
-                            mainResourceId={id}
-                            childId={childId}
-                            targetResourcesString={targetResourcesStr}
-                          />
+                          <SelectedDatePeriodsProvider>
+                            <ResourcePage
+                              mainResourceId={id}
+                              childId={childId}
+                              targetResourcesString={targetResourcesStr}
+                            />
+                          </SelectedDatePeriodsProvider>
                         </Main>
                       </NavigationAndFooterWrapper>
                     )
@@ -168,10 +171,12 @@ const App = (): JSX.Element => {
                     id && (
                       <NavigationAndFooterWrapper>
                         <Main id="main">
-                          <ResourceBatchUpdatePage
-                            mainResourceId={id}
-                            targetResourcesString={targetResourcesStr}
-                          />
+                          <SelectedDatePeriodsProvider>
+                            <ResourceBatchUpdatePage
+                              mainResourceId={id}
+                              targetResourcesString={targetResourcesStr}
+                            />
+                          </SelectedDatePeriodsProvider>
                         </Main>
                       </NavigationAndFooterWrapper>
                     )

--- a/src/common/lib/types.ts
+++ b/src/common/lib/types.ts
@@ -253,6 +253,12 @@ export type OpeningHours = {
   timeSpanGroups: TimeSpanGroup[];
 };
 
+export enum DatePeriodType {
+  NORMAL = 'NORMAL',
+  EXCEPTION = 'EXCEPTION',
+  HOLIDAY = 'HOLIDAY',
+}
+
 export type DatePeriod = {
   id?: number;
   endDate: string | null;
@@ -262,11 +268,9 @@ export type DatePeriod = {
   startDate: string | null;
   override: boolean;
   resourceState?: ResourceState;
+  type?: DatePeriodType;
+  isActive?: boolean;
 };
-
-export type ActiveDatePeriod = {
-  isActive: boolean;
-} & DatePeriod;
 
 export type PreviewOpeningHours = {
   timeSpans: TimeSpan[];

--- a/src/common/selectedDatePeriodsContext/SelectedDatePeriodsContext.test.tsx
+++ b/src/common/selectedDatePeriodsContext/SelectedDatePeriodsContext.test.tsx
@@ -1,0 +1,210 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useContext } from 'react';
+import {
+  SelectedDatePeriodsProvider,
+  SelectedDatePeriodsContext,
+} from './SelectedDatePeriodsContext';
+import { DatePeriod, DatePeriodType } from '../lib/types';
+
+const datePeriod: DatePeriod = {
+  id: 1,
+  endDate: '2022-01-31',
+  fixed: true,
+  name: { fi: 'Test period', sv: 'Test period', en: 'Test period' },
+  openingHours: [],
+  startDate: '2022-01-01',
+  override: false,
+};
+
+const datePeriodTwo: DatePeriod = {
+  id: 2,
+  endDate: '2022-01-31',
+  fixed: true,
+  name: { fi: 'Test period 2', sv: 'Test period 2', en: 'Test period 2' },
+  openingHours: [],
+  startDate: '2022-01-01',
+  override: false,
+};
+
+const datePeriodThree: DatePeriod = {
+  id: 3,
+  endDate: '2022-01-31',
+  fixed: true,
+  name: { fi: 'Test period 3', sv: 'Test period 3', en: 'Test period 3' },
+  openingHours: [],
+  startDate: '2022-01-01',
+  override: false,
+};
+
+describe('SelectedDatePeriodsContext', () => {
+  it('toggleDatePeriod function changes the state as expected', () => {
+    const { result } = renderHook(
+      () => useContext(SelectedDatePeriodsContext),
+      {
+        wrapper: SelectedDatePeriodsProvider,
+      }
+    );
+
+    act(() => {
+      result?.current?.toggleDatePeriod(datePeriod);
+    });
+
+    act(() => {
+      result?.current?.toggleDatePeriod(datePeriodTwo);
+    });
+
+    act(() => {
+      result?.current?.toggleDatePeriod(datePeriodThree);
+    });
+
+    expect(result?.current?.selectedDatePeriods).toEqual(
+      expect.arrayContaining([datePeriod, datePeriodTwo, datePeriodThree])
+    );
+
+    act(() => {
+      result?.current?.toggleDatePeriod(datePeriodTwo);
+    });
+
+    expect(result?.current?.selectedDatePeriods).toHaveLength(2);
+
+    expect(result?.current?.selectedDatePeriods).toEqual([
+      datePeriod,
+      datePeriodThree,
+    ]);
+  });
+
+  it('clearDatePeriods function changes the state as expected', () => {
+    const { result } = renderHook(
+      () => useContext(SelectedDatePeriodsContext),
+      {
+        wrapper: SelectedDatePeriodsProvider,
+      }
+    );
+
+    act(() => {
+      result?.current?.clearDatePeriods();
+    });
+
+    expect(result?.current?.selectedDatePeriods).toHaveLength(0);
+  });
+
+  it('addDatePeriodIds function changes the state as expected', () => {
+    const { result } = renderHook(
+      () => useContext(SelectedDatePeriodsContext),
+      {
+        wrapper: SelectedDatePeriodsProvider,
+      }
+    );
+
+    act(() => {
+      result?.current?.addDatePeriods([datePeriod, datePeriodTwo]);
+    });
+
+    act(() => {
+      result?.current?.addDatePeriods([datePeriodTwo]);
+    });
+
+    expect(result?.current?.selectedDatePeriods).toEqual([
+      datePeriod,
+      datePeriodTwo,
+    ]);
+
+    expect(result?.current?.selectedDatePeriods).toHaveLength(2);
+
+    act(() => {
+      result?.current?.addDatePeriods([datePeriodThree]);
+    });
+
+    expect(result?.current?.selectedDatePeriods).toEqual([
+      datePeriod,
+      datePeriodTwo,
+      datePeriodThree,
+    ]);
+  });
+
+  it('removeDatePeriodIds function changes the state as expected', () => {
+    const { result } = renderHook(
+      () => useContext(SelectedDatePeriodsContext),
+      {
+        wrapper: SelectedDatePeriodsProvider,
+      }
+    );
+
+    act(() => {
+      result?.current?.clearDatePeriods();
+    });
+
+    act(() => {
+      result?.current?.addDatePeriods([datePeriod, datePeriodTwo]);
+    });
+
+    expect(result?.current?.selectedDatePeriods).toHaveLength(2);
+
+    act(() => {
+      result?.current?.removeDatePeriods([datePeriod, datePeriodThree]);
+    });
+
+    expect(result?.current?.selectedDatePeriods).toEqual([datePeriodTwo]);
+    expect(result?.current?.selectedDatePeriods).toHaveLength(1);
+  });
+
+  it('removeDatePeriodIds function changes the state as expected', () => {
+    const { result } = renderHook(
+      () => useContext(SelectedDatePeriodsContext),
+      {
+        wrapper: SelectedDatePeriodsProvider,
+      }
+    );
+
+    act(() => {
+      result?.current?.clearDatePeriods();
+    });
+
+    act(() => {
+      result?.current?.addDatePeriods([datePeriod, datePeriodTwo]);
+    });
+
+    expect(result?.current?.selectedDatePeriods).toHaveLength(2);
+
+    act(() => {
+      result?.current?.removeDatePeriods([datePeriod, datePeriodThree]);
+    });
+
+    expect(result?.current?.selectedDatePeriods).toEqual([datePeriodTwo]);
+    expect(result?.current?.selectedDatePeriods).toHaveLength(1);
+  });
+
+  it('updateSelectedDatePeriods function changes the state as expected', () => {
+    const { result } = renderHook(
+      () => useContext(SelectedDatePeriodsContext),
+      {
+        wrapper: SelectedDatePeriodsProvider,
+      }
+    );
+
+    act(() => {
+      result?.current?.clearDatePeriods();
+    });
+
+    act(() => {
+      result?.current?.addDatePeriods([
+        datePeriod,
+        datePeriodTwo,
+        datePeriodThree,
+      ]);
+    });
+
+    const copiesWithTypes: DatePeriod[] = [
+      { ...datePeriod, type: DatePeriodType.NORMAL },
+      { ...datePeriodTwo, type: DatePeriodType.EXCEPTION },
+      { ...datePeriodThree, type: DatePeriodType.HOLIDAY },
+    ];
+
+    act(() => {
+      result?.current?.updateSelectedDatePeriods(copiesWithTypes);
+    });
+
+    expect(result?.current?.selectedDatePeriods).toEqual(copiesWithTypes);
+    expect(result?.current?.selectedDatePeriods).toHaveLength(3);
+  });
+});

--- a/src/common/selectedDatePeriodsContext/SelectedDatePeriodsContext.tsx
+++ b/src/common/selectedDatePeriodsContext/SelectedDatePeriodsContext.tsx
@@ -1,0 +1,152 @@
+import React, {
+  createContext,
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+} from 'react';
+import store from '../utils/storage/sessionStorage';
+import { DatePeriod } from '../lib/types';
+
+export enum DatePeriodSelectState {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  DISABLED = 'DISABLED',
+}
+
+export type SelectedDatePeriodsContextType = {
+  addDatePeriods: (datePeriods: DatePeriod[]) => void;
+  clearDatePeriods: () => void;
+  datePeriodSelectState: DatePeriodSelectState;
+  removeDatePeriods: (datePeriods: DatePeriod[]) => void;
+  selectedDatePeriods: DatePeriod[];
+  setDatePeriodSelectState: (state: DatePeriodSelectState) => void;
+  toggleDatePeriod: (datePeriod: DatePeriod) => void;
+  updateSelectedDatePeriods: (datePeriods: DatePeriod[]) => void;
+};
+
+export const SelectedDatePeriodsContext = createContext<
+  SelectedDatePeriodsContextType | undefined
+>(undefined);
+
+export const SelectedDatePeriodsProvider: React.FC = ({ children }) => {
+  const [selectedDatePeriods, setSelectedDatePeriods] = useState<DatePeriod[]>(
+    () => {
+      const storedDatePeriods: DatePeriod[] =
+        store.getItem('selectedDatePeriods') ?? [];
+      return storedDatePeriods;
+    }
+  );
+
+  const [datePeriodSelectState, setDatePeriodSelectState] =
+    useState<DatePeriodSelectState>(DatePeriodSelectState.DISABLED);
+
+  useEffect(() => {
+    store.storeItem({ key: 'selectedDatePeriods', value: selectedDatePeriods });
+  }, [selectedDatePeriods]);
+
+  // toggles datePeriods in selectedDatePeriods
+  const toggleDatePeriod = useCallback(
+    (datePeriod: DatePeriod) => {
+      const included = selectedDatePeriods.some(
+        (dp) => dp.id === datePeriod.id
+      );
+      if (included) {
+        const filteredDatePeriods = selectedDatePeriods.filter(
+          (dp) => dp.id !== datePeriod.id
+        );
+        setSelectedDatePeriods(filteredDatePeriods);
+      } else {
+        const combinedDatePeriods = [...selectedDatePeriods, datePeriod];
+        setSelectedDatePeriods(combinedDatePeriods);
+      }
+    },
+    [selectedDatePeriods]
+  );
+
+  // checks if all given datePeriods are already in selectedDatePeriods and if they all have type in selectedDatePeriods
+  const updateSelectedDatePeriods = useCallback(
+    (datePeriods: DatePeriod[]) => {
+      const allDatePeriodsIncludedWithType = datePeriods.every((dp) =>
+        selectedDatePeriods.some(
+          (sdp) => sdp.id === dp.id && sdp.type === dp.type
+        )
+      );
+
+      if (!allDatePeriodsIncludedWithType) {
+        setSelectedDatePeriods(datePeriods);
+      }
+    },
+    [selectedDatePeriods]
+  );
+
+  // adds datePeriods to selectedDatePeriods not duplicating existing ones
+  const addDatePeriods = useCallback(
+    (datePeriods: DatePeriod[]) => {
+      const datePeriodsToBeAdded = datePeriods.filter((dp) => {
+        return !selectedDatePeriods.some((sdp) => sdp.id === dp.id);
+      });
+
+      const combinedDatePeriods = [
+        ...selectedDatePeriods,
+        ...datePeriodsToBeAdded,
+      ];
+      setSelectedDatePeriods(combinedDatePeriods);
+    },
+    [setSelectedDatePeriods, selectedDatePeriods]
+  );
+
+  // removes datePeriods from selectedDatePeriods
+  const removeDatePeriods = useCallback(
+    (datePeriods: DatePeriod[]) => {
+      const filteredDatePeriods = selectedDatePeriods.filter(
+        (dp) => !datePeriods.some((sdp) => sdp.id === dp.id)
+      );
+      setSelectedDatePeriods(filteredDatePeriods);
+    },
+    [selectedDatePeriods]
+  );
+
+  const clearDatePeriods = useCallback(() => {
+    setSelectedDatePeriods([]);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      clearDatePeriods,
+      datePeriodSelectState,
+      setDatePeriodSelectState,
+      selectedDatePeriods,
+      toggleDatePeriod,
+      addDatePeriods,
+      removeDatePeriods,
+      updateSelectedDatePeriods,
+    }),
+    [
+      addDatePeriods,
+      clearDatePeriods,
+      datePeriodSelectState,
+      removeDatePeriods,
+      selectedDatePeriods,
+      toggleDatePeriod,
+      updateSelectedDatePeriods,
+    ]
+  );
+
+  return (
+    <SelectedDatePeriodsContext.Provider value={value}>
+      {children}
+    </SelectedDatePeriodsContext.Provider>
+  );
+};
+
+export const useSelectedDatePeriodsContext =
+  (): SelectedDatePeriodsContextType => {
+    const context = React.useContext(SelectedDatePeriodsContext);
+    if (context === undefined) {
+      throw new Error(
+        'useSelectedDatePeriodsContext must be used within a SelectedDatePeriodsProvider'
+      );
+    }
+    return context;
+  };

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -373,4 +373,21 @@ export default {
     });
     return permission.has_permission;
   },
+
+  batchCopyDatePeriods: async (
+    resourceId: number,
+    targetResources: string[],
+    datePeriodIds: string[],
+    replace: boolean
+  ): Promise<boolean> => {
+    const permission = await apiPost<PermissionResponse>({
+      path: `${resourceBasePath}/${resourceId}/copy_date_periods`,
+      parameters: {
+        replace,
+        target_resources: targetResources.join(','),
+        date_period_ids: datePeriodIds.join(','),
+      },
+    });
+    return permission.has_permission;
+  },
 };

--- a/src/common/utils/api/api.ts
+++ b/src/common/utils/api/api.ts
@@ -362,30 +362,15 @@ export default {
   copyDatePeriods: async (
     resourceId: number,
     targetResources: string[],
-    replace: boolean
+    replace: boolean,
+    datePeriodIds?: string[]
   ): Promise<boolean> => {
     const permission = await apiPost<PermissionResponse>({
       path: `${resourceBasePath}/${resourceId}/copy_date_periods`,
       parameters: {
         replace,
         target_resources: targetResources.join(','),
-      },
-    });
-    return permission.has_permission;
-  },
-
-  batchCopyDatePeriods: async (
-    resourceId: number,
-    targetResources: string[],
-    datePeriodIds: string[],
-    replace: boolean
-  ): Promise<boolean> => {
-    const permission = await apiPost<PermissionResponse>({
-      path: `${resourceBasePath}/${resourceId}/copy_date_periods`,
-      parameters: {
-        replace,
-        target_resources: targetResources.join(','),
-        date_period_ids: datePeriodIds.join(','),
+        date_period_ids: datePeriodIds?.join(','),
       },
     });
     return permission.has_permission;

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,6 +1,6 @@
 import {
-  Button as HDSButton,
   ButtonSize,
+  Button as HDSButton,
   ButtonSize as HDSButtonSize,
 } from 'hds-react';
 import React, { ReactNode } from 'react';
@@ -21,6 +21,7 @@ interface ButtonProps {
   loadingText?: string;
   size?: ButtonSize;
   'aria-expanded'?: boolean;
+  style?: React.CSSProperties;
 }
 
 type SecondaryButtonProps = ButtonProps & {
@@ -47,6 +48,7 @@ export const SecondaryButton = React.forwardRef<
       light = false,
       size = 'default',
       'aria-expanded': ariaExpanded,
+      style,
     }: SecondaryButtonProps,
     ref
   ): JSX.Element => {
@@ -67,7 +69,8 @@ export const SecondaryButton = React.forwardRef<
         iconLeft={iconLeft}
         iconRight={iconRight}
         isLoading={isLoading}
-        loadingText={loadingText}>
+        loadingText={loadingText}
+        style={style}>
         {children}
       </HDSButton>
     );
@@ -89,6 +92,7 @@ export const PrimaryButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
       loadingText,
       size = 'default',
       'aria-expanded': ariaExpanded,
+      style,
     }: ButtonProps,
     ref
   ): JSX.Element => {
@@ -108,7 +112,8 @@ export const PrimaryButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled}
         isLoading={isLoading}
         loadingText={loadingText}
-        size={size}>
+        size={size}
+        style={style}>
         {children}
       </HDSButton>
     );
@@ -133,6 +138,7 @@ export const SupplementaryButton = React.forwardRef<
       loadingText,
       size = 'default',
       'aria-expanded': ariaExpanded,
+      style,
     },
     ref
   ): JSX.Element => {
@@ -150,7 +156,8 @@ export const SupplementaryButton = React.forwardRef<
         isLoading={isLoading}
         loadingText={loadingText}
         disabled={disabled}
-        size={size}>
+        size={size}
+        style={style}>
         {children}
       </HDSButton>
     );

--- a/src/components/collapse/Collapse.test.tsx
+++ b/src/components/collapse/Collapse.test.tsx
@@ -15,7 +15,7 @@ describe(`<Collapse />`, () => {
 
     expect(collapse.find('h3').text()).toEqual('Test Title');
     expect(collapse.find('#test-content').getDOMNode()).toHaveClass(
-      'hiddenFromScreen'
+      'visually-hidden'
     );
   });
 
@@ -32,7 +32,7 @@ describe(`<Collapse />`, () => {
     collapse.find('button').simulate('click');
 
     expect(collapse.find('#test-content').getDOMNode()).not.toHaveClass(
-      'hiddenFromScreen'
+      'visually-hidden'
     );
   });
 });

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -80,7 +80,7 @@ const Collapse = ({
         id={collapseContentId}
         role="region"
         aria-labelledby={buttonId}
-        className={`collapse-content ${!isOpenState ? 'hiddenFromScreen' : ''}`}
+        className={`collapse-content ${!isOpenState ? 'visually-hidden' : ''}`}
         hidden={!isOpenState}>
         {children}
       </div>

--- a/src/components/holidays-table/HolidaysTable.scss
+++ b/src/components/holidays-table/HolidaysTable.scss
@@ -57,6 +57,7 @@
 
 .holidays-table__cell--name {
   font-weight: bold;
+  display: flex;
 }
 
 .holidays-table__cell--date {

--- a/src/components/opening-hours-preview/OpeningHoursPreview.tsx
+++ b/src/components/opening-hours-preview/OpeningHoursPreview.tsx
@@ -153,7 +153,7 @@ const OpeningHoursPreview = ({
                 {uiRuleLabels[previewRow.rule.type][language]}
               </caption>
             )}
-            <thead className="opening-hours-preview-table__header hiddenFromScreen">
+            <thead className="opening-hours-preview-table__header visually-hidden">
               <tr>
                 <th
                   className="opening-hours-preview-table__day-column"

--- a/src/components/opening-period/OpeningPeriod.scss
+++ b/src/components/opening-period/OpeningPeriod.scss
@@ -5,6 +5,7 @@
   box-sizing: border-box;
   background-color: var(--opening-period-background-color);
   padding: $spacing-xs $spacing-m;
+  border-bottom: 1px solid var(--color-black-60);
 
   h4 {
     font-size: $fontsize-body-l;
@@ -18,6 +19,7 @@
   justify-content: space-between;
   flex-wrap: wrap;
   margin-left: -$spacing-m;
+  align-items: center;
 
   > * {
     margin-left: $spacing-m;

--- a/src/components/opening-period/OpeningPeriod.test.tsx
+++ b/src/components/opening-period/OpeningPeriod.test.tsx
@@ -4,27 +4,30 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { datePeriodOptions } from '../../../test/fixtures/api-options';
 import { datePeriod } from '../../../test/fixtures/date-period';
 import {
-  ActiveDatePeriod,
+  DatePeriod,
   Language,
   UiDatePeriodConfig,
 } from '../../common/lib/types';
 import OpeningPeriod from './OpeningPeriod';
+import { SelectedDatePeriodsProvider } from '../../common/selectedDatePeriodsContext/SelectedDatePeriodsContext';
 
-const testDatePeriod: ActiveDatePeriod = { ...datePeriod, isActive: false };
+const testDatePeriod: DatePeriod = { ...datePeriod, isActive: false };
 const testDatePeriodOptions: UiDatePeriodConfig = datePeriodOptions;
 
 describe(`<OpeningPeriod />`, () => {
   it('should show opening period', async () => {
     const { container } = render(
       <Router>
-        <OpeningPeriod
-          editUrl="some-url"
-          initiallyOpen={false}
-          datePeriod={testDatePeriod}
-          language={Language.FI}
-          datePeriodConfig={testDatePeriodOptions}
-          deletePeriod={(): Promise<void> => Promise.resolve()}
-        />
+        <SelectedDatePeriodsProvider>
+          <OpeningPeriod
+            editUrl="some-url"
+            initiallyOpen={false}
+            datePeriod={testDatePeriod}
+            language={Language.FI}
+            datePeriodConfig={testDatePeriodOptions}
+            deletePeriod={(): Promise<void> => Promise.resolve()}
+          />
+        </SelectedDatePeriodsProvider>
       </Router>
     );
 

--- a/src/components/opening-period/OpeningPeriod.tsx
+++ b/src/components/opening-period/OpeningPeriod.tsx
@@ -3,13 +3,17 @@ import {
   Language,
   UiDatePeriodConfig,
   ResourceState,
-  ActiveDatePeriod,
+  DatePeriod,
 } from '../../common/lib/types';
 import { formatDateRange } from '../../common/utils/date-time/format';
 import './OpeningPeriod.scss';
 import OpeningHoursPreview from '../opening-hours-preview/OpeningHoursPreview';
 import OpeningPeriodAccordion from '../opening-period-accordion/OpeningPeriodAccordion';
 import { getDatePeriodName } from '../../common/helpers/opening-hours-helpers';
+import {
+  DatePeriodSelectState,
+  useSelectedDatePeriodsContext,
+} from '../../common/selectedDatePeriodsContext/SelectedDatePeriodsContext';
 
 const OpeningPeriod = ({
   datePeriod,
@@ -19,40 +23,59 @@ const OpeningPeriod = ({
   deletePeriod,
   initiallyOpen = false,
 }: {
-  datePeriod: ActiveDatePeriod;
+  datePeriod: DatePeriod;
   datePeriodConfig?: UiDatePeriodConfig;
-  editUrl: string;
+  editUrl?: string;
   language: Language;
-  deletePeriod: (id: number) => Promise<void>;
+  deletePeriod?: (id: number) => Promise<void>;
   initiallyOpen: boolean;
-}): JSX.Element => (
-  <OpeningPeriodAccordion
-    id={`${datePeriod.id}`}
-    periodName={getDatePeriodName(language, datePeriod)}
-    dateRange={formatDateRange({
-      startDate: datePeriod.startDate,
-      endDate: datePeriod.endDate,
-    })}
-    onDelete={(): Promise<void> => {
-      if (datePeriod.id) {
-        return deletePeriod(datePeriod.id);
-      }
-      return Promise.resolve();
-    }}
-    editUrl={editUrl}
-    initiallyOpen={initiallyOpen}
-    isActive={datePeriod.isActive}>
-    <div className="date-period-details-container">
-      {datePeriod.resourceState === ResourceState.CLOSED ? (
-        'Suljettu'
-      ) : (
-        <OpeningHoursPreview
-          openingHours={datePeriod.openingHours}
-          resourceStates={datePeriodConfig?.resourceState.options ?? []}
-        />
-      )}
-    </div>
-  </OpeningPeriodAccordion>
-);
+}): JSX.Element => {
+  const {
+    selectedDatePeriods,
+    toggleDatePeriod,
+    removeDatePeriods,
+    datePeriodSelectState,
+  } = useSelectedDatePeriodsContext();
+
+  const toggleChecked =
+    datePeriodSelectState === DatePeriodSelectState.ACTIVE
+      ? (): void => {
+          toggleDatePeriod(datePeriod);
+        }
+      : undefined;
+
+  return (
+    <OpeningPeriodAccordion
+      id={`${datePeriod.id}`}
+      toggleChecked={toggleChecked}
+      checked={selectedDatePeriods.some((dp) => dp.id === datePeriod.id)}
+      periodName={getDatePeriodName(language, datePeriod)}
+      dateRange={formatDateRange({
+        startDate: datePeriod.startDate,
+        endDate: datePeriod.endDate,
+      })}
+      onDelete={(): Promise<void> => {
+        removeDatePeriods([datePeriod]);
+        if (datePeriod.id && deletePeriod) {
+          return deletePeriod(datePeriod.id);
+        }
+        return Promise.resolve();
+      }}
+      editUrl={editUrl}
+      initiallyOpen={initiallyOpen}
+      isActive={datePeriod.isActive}>
+      <div className="date-period-details-container">
+        {datePeriod.resourceState === ResourceState.CLOSED ? (
+          'Suljettu'
+        ) : (
+          <OpeningHoursPreview
+            openingHours={datePeriod.openingHours}
+            resourceStates={datePeriodConfig?.resourceState.options ?? []}
+          />
+        )}
+      </div>
+    </OpeningPeriodAccordion>
+  );
+};
 
 export default OpeningPeriod;

--- a/src/components/opening-periods-list/OpeningPeriodsList.tsx
+++ b/src/components/opening-periods-list/OpeningPeriodsList.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  ActiveDatePeriod,
   DatePeriod,
   Language,
   UiDatePeriodConfig,
@@ -33,7 +32,7 @@ const OpeningPeriodsList = ({
   addNewOpeningPeriodButtonDataTest: string;
   addDatePeriodButtonText: string;
   title: string;
-  datePeriods: ActiveDatePeriod[];
+  datePeriods: DatePeriod[];
   datePeriodConfig?: UiDatePeriodConfig;
   theme: PeriodsListTheme;
   emptyState: string;
@@ -41,7 +40,7 @@ const OpeningPeriodsList = ({
   language: Language;
   isLoading: boolean;
   newUrl: string;
-  editUrl: (datePeriod: DatePeriod) => string;
+  editUrl?: (datePeriod: DatePeriod) => string;
 }): JSX.Element => {
   const ref = React.useRef<HTMLButtonElement>(null);
 
@@ -61,7 +60,7 @@ const OpeningPeriodsList = ({
           <OpeningPeriod
             key={datePeriod.id}
             datePeriodConfig={datePeriodConfig}
-            editUrl={editUrl(datePeriod)}
+            editUrl={editUrl && editUrl(datePeriod)}
             datePeriod={datePeriod}
             language={language}
             deletePeriod={async (datePeriodId) => {

--- a/src/components/opening-periods-section/OpeningPeriodsSection.tsx
+++ b/src/components/opening-periods-section/OpeningPeriodsSection.tsx
@@ -1,9 +1,13 @@
-import { LoadingSpinner } from 'hds-react';
+import { Checkbox, LoadingSpinner } from 'hds-react';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { DatePeriod } from '../../common/lib/types';
 import { PrimaryButton, SecondaryButton } from '../button/Button';
 import './OpeningPeriodsSection.scss';
+import {
+  DatePeriodSelectState,
+  useSelectedDatePeriodsContext,
+} from '../../common/selectedDatePeriodsContext/SelectedDatePeriodsContext';
 
 type Props = {
   addDatePeriodButtonRef?: React.Ref<HTMLButtonElement>;
@@ -31,32 +35,89 @@ const OpeningPeriodsSection = ({
   theme,
 }: Props): JSX.Element => {
   const history = useHistory();
+  const {
+    selectedDatePeriods,
+    removeDatePeriods,
+    addDatePeriods,
+    datePeriodSelectState,
+  } = useSelectedDatePeriodsContext();
   const openingPeriodsHeaderClassName =
     theme === 'LIGHT'
       ? 'opening-periods-header-light'
       : 'opening-periods-header';
 
+  // custom checkbox style for default style TODO: FINALS?
+  const customCheckboxStyle =
+    theme === 'DEFAULT'
+      ? {
+          backgroundColor: 'var(--color-white)',
+          '--background-selected': 'var(--color-coat-of-arms)',
+          '--border-color-selected': 'var(--color-coat-of-arms)',
+        }
+      : {};
+
   const Button = theme === 'LIGHT' ? PrimaryButton : SecondaryButton;
+
+  const noOfSelectedDatePeriods = selectedDatePeriods.filter((sdp) =>
+    datePeriods.some((dp) => dp.id === sdp.id)
+  ).length;
+
+  const someSelectedDatePeriods =
+    noOfSelectedDatePeriods > 0 && noOfSelectedDatePeriods < datePeriods.length;
+
+  const allChecked =
+    noOfSelectedDatePeriods === datePeriods.length && datePeriods.length > 0;
+
+  const onChangeHandler = (): void => {
+    if (!allChecked) {
+      addDatePeriods(datePeriods);
+    } else {
+      removeDatePeriods(datePeriods);
+    }
+  };
+
+  const combinedIdsString = `all-periods-checkbox-${datePeriods
+    .map((dp) => dp.id)
+    .join('-')}`;
 
   return (
     <section className="opening-periods-section">
       <header className={openingPeriodsHeaderClassName}>
-        <h2 className="opening-periods-header-title">{title}</h2>
+        {datePeriodSelectState === DatePeriodSelectState.ACTIVE && (
+          <Checkbox
+            label={undefined}
+            id={combinedIdsString}
+            checked={allChecked}
+            indeterminate={someSelectedDatePeriods}
+            onChange={onChangeHandler}
+            disabled={datePeriods.length === 0}
+            style={customCheckboxStyle as React.CSSProperties}
+          />
+        )}
+        <h2 className="opening-periods-header-title">
+          {datePeriodSelectState === DatePeriodSelectState.ACTIVE ? (
+            <label htmlFor={combinedIdsString}>{title}</label>
+          ) : (
+            title
+          )}
+        </h2>
         <p className="opening-periods-period-count">
           {datePeriods.length}{' '}
           {datePeriods.length === 1 ? 'aukioloaika' : 'aukioloaikaa'}
         </p>
-        <Button
-          ref={addDatePeriodButtonRef}
-          className="opening-period-header-button"
-          dataTest={addNewOpeningPeriodButtonDataTest}
-          light
-          onClick={(): void => {
-            history.push(newUrl);
-          }}
-          size="small">
-          {addDatePeriodButtonText}
-        </Button>
+        {datePeriodSelectState !== DatePeriodSelectState.INACTIVE && (
+          <Button
+            ref={addDatePeriodButtonRef}
+            className="opening-period-header-button"
+            dataTest={addNewOpeningPeriodButtonDataTest}
+            light
+            onClick={(): void => {
+              history.push(newUrl);
+            }}
+            size="small">
+            {addDatePeriodButtonText}
+          </Button>
+        )}
       </header>
       {isLoading ? (
         <div className="opening-period-loading-spinner-container">

--- a/src/components/time-span/TimeSpan.tsx
+++ b/src/components/time-span/TimeSpan.tsx
@@ -279,7 +279,7 @@ const TimeSpan = ({
       <div className="remove-time-span-button">
         {onDelete && (
           <SupplementaryButton iconLeft={<IconTrash />} onClick={onDelete}>
-            Poista rivi<span className="hiddenFromScreen">{groupLabel}</span>
+            Poista rivi<span className="visually-hidden">{groupLabel}</span>
           </SupplementaryButton>
         )}
       </div>

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -283,7 +283,7 @@ const HolidayListItem = ({
                     onClick={() => setIsEditing(true)}
                     type="button">
                     <IconPenLine aria-hidden="true" />
-                    <span className="hiddenFromScreen">{`Muokkaa ${holiday} aukiolojakson tietoja`}</span>
+                    <span className="visually-hidden">{`Muokkaa ${holiday} aukiolojakson tietoja`}</span>
                   </button>
                 )}
               </>
@@ -397,7 +397,7 @@ const EditHolidaysPage = ({
     }
 
     return api
-      .deleteDatePeriod(values.id)
+      .deleteDatePeriod(Number(values.id))
       .then(() => {
         toast.success({
           dataTestId: 'holiday-form-success',

--- a/src/pages/ResourceBatchUpdatePage.scss
+++ b/src/pages/ResourceBatchUpdatePage.scss
@@ -19,6 +19,11 @@
     }
   }
 
+  .opening-periods-section {
+    padding: 0;
+    gap: 0;
+  }
+
   .section-title {
     display: flex;
     justify-content: space-between;

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -141,13 +141,13 @@ const ResourceBatchUpdatePage = ({
 
     setLoading(true);
     api
-      .batchCopyDatePeriods(
+      .copyDatePeriods(
         resource?.id || 0,
         targetResourceData?.targetResources
           .filter((item) => item.id !== mainResourceId)
           .map((item) => item.id),
-        datePeriodIds,
-        selectedRadioItem === 'update'
+        selectedRadioItem === 'update',
+        datePeriodIds
       )
       .then(async () => {
         setLoading(false);

--- a/src/pages/ResourcePage.test.tsx
+++ b/src/pages/ResourcePage.test.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable global-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { render, screen } from '@testing-library/react';
@@ -9,11 +11,13 @@ import {
   ResourceState,
   ResourceType,
   UiDatePeriodConfig,
+  // DatePeriod,
 } from '../common/lib/types';
 import api from '../common/utils/api/api';
 import * as datePeriodConfigService from '../services/datePeriodFormConfig';
 import ResourcePage from './ResourcePage';
 import * as holidays from '../services/holidays';
+import { SelectedDatePeriodsProvider } from '../common/selectedDatePeriodsContext/SelectedDatePeriodsContext';
 
 const testResource: Resource = {
   id: 1186,
@@ -110,6 +114,127 @@ const testDatePeriod: ApiDatePeriod = {
 
 const testDatePeriodOptions: UiDatePeriodConfig = datePeriodOptions;
 
+const testDatePeriodWithTimeSpans: ApiDatePeriod[] = [
+  {
+    id: 155,
+    resource: 7108,
+    name: {
+      fi: 'oma syntymäpäivä',
+      sv: null,
+      en: null,
+    },
+    description: {
+      fi: null,
+      sv: null,
+      en: null,
+    },
+    start_date: '2023-11-09',
+    end_date: null,
+    resource_state: undefined,
+    override: false,
+    created: '2023-11-09T12:03:47.039454+02:00',
+    modified: '2023-11-09T12:03:47.039454+02:00',
+    time_span_groups: [
+      {
+        id: 81,
+        period: 155,
+        time_spans: [
+          {
+            id: 124,
+            group: 81,
+            name: {
+              fi: null,
+              sv: null,
+              en: null,
+            },
+            description: {
+              fi: null,
+              sv: null,
+              en: null,
+            },
+            start_time: '11:11:00',
+            end_time: '12:12:00',
+            end_time_on_next_day: false,
+            full_day: false,
+            weekdays: [1, 2, 3, 4, 5],
+            resource_state: ResourceState.OPEN,
+            created: '2023-11-09T12:03:47.069756+02:00',
+            modified: '2023-11-09T12:03:47.069756+02:00',
+          },
+          {
+            id: 125,
+            group: 81,
+            name: {
+              fi: null,
+              sv: null,
+              en: null,
+            },
+            description: {
+              fi: null,
+              sv: null,
+              en: null,
+            },
+            start_time: null,
+            end_time: null,
+            end_time_on_next_day: false,
+            full_day: false,
+            weekdays: [6, 7],
+            resource_state: ResourceState.CLOSED,
+            created: '2023-11-09T12:03:47.087391+02:00',
+            modified: '2023-11-09T12:03:47.087391+02:00',
+          },
+        ],
+        rules: [],
+      },
+    ],
+  },
+  {
+    id: 150,
+    resource: 7108,
+    name: {
+      fi: 'Isänpäivä',
+      sv: 'Fars dag',
+      en: "Father's Day",
+    },
+    description: {
+      fi: null,
+      sv: null,
+      en: null,
+    },
+    start_date: '2023-11-12',
+    end_date: '2023-11-12',
+    resource_state: ResourceState.CLOSED,
+    override: true,
+    created: '2023-11-09T10:58:21.111692+02:00',
+    modified: '2023-11-09T10:58:21.111692+02:00',
+    time_span_groups: [],
+  },
+  {
+    id: 172,
+    resource: 7108,
+    name: {
+      fi: '2. joulupäivä',
+      sv: 'Annandag jul',
+      en: 'Boxing Day',
+    },
+    description: {
+      fi: null,
+      sv: null,
+      en: null,
+    },
+    start_date: '2023-12-26',
+    end_date: '2023-12-26',
+    resource_state: ResourceState.CLOSED,
+    override: true,
+    created: '2023-11-13T10:40:50.286343+02:00',
+    modified: '2023-11-13T10:40:50.286343+02:00',
+    time_span_groups: [],
+  },
+];
+
+// Mock for using useGoToResourceBatchUpdatePage hook
+const mockUseGoToResourceBatchUpdatePage = jest.fn();
+
 describe(`<ResourcePage />`, () => {
   beforeEach(() => {
     jest
@@ -143,6 +268,10 @@ describe(`<ResourcePage />`, () => {
         official: true,
       },
     ]);
+
+    jest
+      .spyOn(require('../hooks/useGoToResourceBatchUpdatePage'), 'default')
+      .mockImplementation(() => mockUseGoToResourceBatchUpdatePage);
   });
   afterEach(() => {
     jest.clearAllMocks();
@@ -156,7 +285,9 @@ describe(`<ResourcePage />`, () => {
 
     render(
       <Router>
-        <ResourcePage mainResourceId="tprek:8100" />
+        <SelectedDatePeriodsProvider>
+          <ResourcePage mainResourceId="tprek:8100" />
+        </SelectedDatePeriodsProvider>
       </Router>
     );
 
@@ -177,7 +308,9 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       render(
         <Router>
-          <ResourcePage mainResourceId="tprek:8100" />
+          <SelectedDatePeriodsProvider>
+            <ResourcePage mainResourceId="tprek:8100" />
+          </SelectedDatePeriodsProvider>
         </Router>
       );
     });
@@ -197,7 +330,9 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       render(
         <Router>
-          <ResourcePage mainResourceId="tprek:8100" />
+          <SelectedDatePeriodsProvider>
+            <ResourcePage mainResourceId="tprek:8100" />
+          </SelectedDatePeriodsProvider>
         </Router>
       );
     });
@@ -214,7 +349,9 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       container = render(
         <Router>
-          <ResourcePage mainResourceId="tprek:8100" />
+          <SelectedDatePeriodsProvider>
+            <ResourcePage mainResourceId="tprek:8100" />
+          </SelectedDatePeriodsProvider>
         </Router>
       ).container;
     });
@@ -239,7 +376,9 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       container = render(
         <Router>
-          <ResourcePage mainResourceId="tprek:8100" />
+          <SelectedDatePeriodsProvider>
+            <ResourcePage mainResourceId="tprek:8100" />
+          </SelectedDatePeriodsProvider>
         </Router>
       ).container;
     });
@@ -255,7 +394,9 @@ describe(`<ResourcePage />`, () => {
     await act(async () => {
       render(
         <Router>
-          <ResourcePage mainResourceId="tprek:8100" />
+          <SelectedDatePeriodsProvider>
+            <ResourcePage mainResourceId="tprek:8100" />
+          </SelectedDatePeriodsProvider>
         </Router>
       );
     });
@@ -269,5 +410,112 @@ describe(`<ResourcePage />`, () => {
         testResource.name.fi
       );
     });
+  });
+
+  it('Should show copying info when targets exist', async () => {
+    jest.spyOn(api, 'getDatePeriods').mockImplementation(() => {
+      return Promise.resolve(testDatePeriodWithTimeSpans);
+    });
+
+    await act(async () => {
+      render(
+        <Router>
+          <SelectedDatePeriodsProvider>
+            <ResourcePage
+              mainResourceId="tprek:8100"
+              targetResourcesString="tprek:8101"
+            />
+          </SelectedDatePeriodsProvider>
+        </Router>
+      );
+    });
+
+    expect(
+      screen.getAllByText('joukkopäivitys', { exact: false })
+    ).not.toBeNull();
+  });
+
+  it('Should show advance to batch copy page and an error if no datePeriods are selected', async () => {
+    jest.spyOn(api, 'getDatePeriods').mockImplementation(() => {
+      return Promise.resolve(testDatePeriodWithTimeSpans);
+    });
+
+    await act(async () => {
+      render(
+        <Router>
+          <SelectedDatePeriodsProvider>
+            <ResourcePage
+              mainResourceId="tprek:8100"
+              targetResourcesString="tprek:8101"
+            />
+          </SelectedDatePeriodsProvider>
+        </Router>
+      );
+    });
+
+    const button = screen.queryByText('Jatka joukkopäivitykseen');
+    expect(button).toBeInTheDocument();
+    button?.click();
+
+    // now we have an error since no datePeriods are chosen
+    expect(
+      screen.getByTestId('gotoBatchUpdateErrorNotification')
+    ).toBeInTheDocument();
+
+    // expect function mockUseGoToResourceBatchUpdatePage to not have been called
+    expect(mockUseGoToResourceBatchUpdatePage).toHaveBeenCalledTimes(0);
+  });
+
+  it('Should show resource copying opening periods with checkboxes and state change according to interaction and forward navigation', async () => {
+    jest.spyOn(api, 'getDatePeriods').mockImplementation(() => {
+      return Promise.resolve(testDatePeriodWithTimeSpans);
+    });
+
+    await act(async () => {
+      render(
+        <Router>
+          <SelectedDatePeriodsProvider>
+            <ResourcePage
+              mainResourceId="tprek:8100"
+              targetResourcesString="tprek:8101"
+            />
+          </SelectedDatePeriodsProvider>
+        </Router>
+      );
+    });
+
+    // get all datePeriods checkboxes
+    const periodCheckboxes = screen
+      .getAllByRole('checkbox')
+      .filter((checkbox) => checkbox.id.includes('period-checkbox'));
+
+    // click all datePeriods checkboxes
+    periodCheckboxes.forEach((checkbox) => {
+      checkbox.click();
+    });
+
+    // expect all datePeriods checkboxes to be checked, showing only "Poista valinnat" button
+    expect(screen.queryByText('Valitse kaikki')).not.toBeInTheDocument();
+    expect(screen.queryByText('Poista valinnat')).toBeInTheDocument();
+
+    // also check if all non-disabled all-periods-checkboxes are checked
+    const allPeriodsCheckboxes = screen
+      .getAllByRole('checkbox')
+      .filter(
+        (checkbox) =>
+          checkbox.id.includes('all-periods') &&
+          checkbox.getAttribute('disabled') === null
+      );
+
+    allPeriodsCheckboxes.forEach((checkbox) => {
+      expect(checkbox).toBeChecked();
+    });
+
+    // and now when button click should hide the error (mock disables navigating any further)
+    const button = screen.queryByText('Jatka joukkopäivitykseen');
+    button?.click();
+
+    // expect function mockUseGoToResourceBatchUpdatePage to have been called now
+    expect(mockUseGoToResourceBatchUpdatePage).toHaveBeenCalledTimes(1);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,6 +2093,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^11.0.2":
   version "11.2.7"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
@@ -11846,6 +11854,13 @@ react-dom@^17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
   version "6.0.9"


### PR DESCRIPTION
- Adds possibility to choose which datePeriods are to be copied to targetResources. There's still a small visual bug with the HDS Checkbox-component since it uses an empty label that takes space even if label is not given. (This is reported to HDS-team and will be fixed sometime). In this UI the headers are used as the label for the checkboxes. (Can be seen in the image below)

![image](https://github.com/City-of-Helsinki/hauki-admin-ui/assets/8654955/fa5125c8-8a45-40cb-9096-68a0383f5b07)

- Also fixes the menu/action buttons labels not being hidden from screen by changing to use the correct css-class that had changed in the new HDS 3.x


Comments are welcome! (And yes, sorry, this is a big PR but still just this one feature added)