### PR TITLE
HAUKI add dismissible prop to errorToast

### DIFF
--- a/src/components/notification/Toast.tsx
+++ b/src/components/notification/Toast.tsx
@@ -11,6 +11,7 @@ type ToastProps = {
   text?: string;
   onClose?: () => void;
   dataTestId?: string;
+  dismissible?: boolean;
 };
 
 const removeContainer = (container: HTMLDivElement): void => {
@@ -28,6 +29,7 @@ const renderToast = ({
   onClose,
   dataTestId,
   position = 'top-right',
+  dismissible = false,
 }: ToastProps & {
   position?: NotificationPosition;
   type: NotificationType;
@@ -39,7 +41,8 @@ const renderToast = ({
     <Notification
       position={position}
       displayAutoCloseProgress={false}
-      autoClose
+      autoClose={!dismissible}
+      dismissible={dismissible}
       label={label}
       type={type}
       onClose={(): void => {
@@ -48,6 +51,7 @@ const renderToast = ({
         }
         removeContainer(containerDomNode);
       }}
+      closeButtonLabelText="Sulje ilmoitus"
       {...(dataTestId ? { dataTestId } : {})}>
       {text}
     </Notification>,
@@ -76,14 +80,24 @@ const errorToast = ({
   dataTestId,
   onClose,
   position,
+  dismissible,
 }: {
   label: string;
   dataTestId?: string;
   onClose?: () => void;
   position?: NotificationPosition;
   text?: string;
+  dismissible?: boolean;
 }): void =>
-  renderToast({ type: 'error', label, text, onClose, dataTestId, position });
+  renderToast({
+    type: 'error',
+    label,
+    text,
+    onClose,
+    dataTestId,
+    position,
+    dismissible,
+  });
 
 const infoToast = ({
   label,

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -98,6 +98,7 @@ const ResourceBatchUpdatePage = ({
     toast.error({
       label,
       text,
+      dismissible: true,
     });
   const showSuccessNotification = (label: string, text?: string): void =>
     toast.success({


### PR DESCRIPTION
Add dismissible prop to errorToast to pass to used HDS-component. This is set in ResourceBatchUpdatePage as true so that the Toast is shown and stays visible until user dismisses it.

![image](https://github.com/City-of-Helsinki/hauki-admin-ui/assets/8654955/38cf38a7-7327-4180-b648-0730a078507d)
