### PR TITLE
fix: missing date period config

### DIFF
--- a/src/pages/ResourceBatchUpdatePage.test.tsx
+++ b/src/pages/ResourceBatchUpdatePage.test.tsx
@@ -260,6 +260,11 @@ jest.mock('react-i18next', () => ({
   },
 }));
 
+jest.mock('../services/useDatePeriodConfig', () => ({
+  __esModule: true,
+  default: jest.fn(() => [false, jest.fn()]),
+}));
+
 const renderPage = () => {
   return render(
     <Router>

--- a/src/pages/ResourceBatchUpdatePage.tsx
+++ b/src/pages/ResourceBatchUpdatePage.tsx
@@ -26,6 +26,7 @@ import { DatePeriodType, Language, Resource } from '../common/lib/types';
 import sessionStorage from '../common/utils/storage/sessionStorage';
 import './ResourceBatchUpdatePage.scss';
 import { TargetResourcesProps } from '../components/resource-opening-hours/ResourcePeriodsCopyFieldset';
+import useDatePeriodConfig from '../services/useDatePeriodConfig';
 import useReturnToResourcePage from '../hooks/useReturnToResourcePage';
 import {
   DatePeriodSelectState,
@@ -82,6 +83,7 @@ const ResourceBatchUpdatePage = ({
     setDatePeriodSelectState,
     datePeriodSelectState,
   } = useSelectedDatePeriodsContext();
+  const datePeriodConfig = useDatePeriodConfig();
   const { t, i18n } = useTranslation();
 
   // page constants
@@ -417,6 +419,7 @@ const ResourceBatchUpdatePage = ({
                 language={language}
                 initiallyOpen={false}
                 editUrl=""
+                datePeriodConfig={datePeriodConfig}
               />
             ))}
           </OpeningPeriodsSection>
@@ -437,6 +440,7 @@ const ResourceBatchUpdatePage = ({
                 language={language}
                 initiallyOpen={false}
                 editUrl=""
+                datePeriodConfig={datePeriodConfig}
               />
             ))}
           </OpeningPeriodsSection>
@@ -457,6 +461,7 @@ const ResourceBatchUpdatePage = ({
                 language={language}
                 initiallyOpen={false}
                 editUrl=""
+                datePeriodConfig={datePeriodConfig}
               />
             ))}
           </OpeningPeriodsSection>


### PR DESCRIPTION
Fixed small bug found on bigger translation feature [HAUKI-610](https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-610). `TimeSpanState`s was shown correctly on page `ResourcePage`, but on next page `ResourceBatchUpdatePage` those state texts was shown as "Tuntematon". Bug was a missing `datePeriodConfig` which is the structure that contains those state strings. 

[HAUKI-610]: https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ