### PR TITLE
fix: missing data-testid

### DIFF
--- a/e2e/tests/resource-page.spec.ts
+++ b/e2e/tests/resource-page.spec.ts
@@ -127,7 +127,7 @@ test.describe('Resource page', async () => {
     const holidayInput = page
       .locator('input[data-test*="holiday-"]:not(:checked):not(:disabled)')
       .first();
-    const holidayTestId = await holidayInput.getAttribute('data-test');
+    const holidayTestId = await holidayInput.getAttribute('data-testid');
 
     await page.locator(`[data-testid="${holidayTestId}"]`).check();
     await page.locator('[data-testid="submit-opening-hours-button"]').click();
@@ -148,7 +148,7 @@ test.describe('Resource page', async () => {
     const holidayInput = page
       .locator('input[data-test*="holiday-"]:not(:checked):not(:disabled)')
       .first();
-    const holidayTestId = await holidayInput.getAttribute('data-test');
+    const holidayTestId = await holidayInput.getAttribute('data-testid');
 
     await page.locator(`[data-testid="${holidayTestId}"]`).check();
     await page.getByText('Poikkeava aukioloaika').click();

--- a/src/pages/EditHolidaysPage.tsx
+++ b/src/pages/EditHolidaysPage.tsx
@@ -187,7 +187,7 @@ const HolidayListItem = ({
   const checkboxId = `${id}-checkbox`;
   const commonCheckBoxProps = {
     id: checkboxId,
-    'data-test': checkboxId,
+    'data-testid': checkboxId,
     label: `${name[language]}   ${formatDate(date)}`,
     checked,
     style: {


### PR DESCRIPTION
[PR](https://github.com/City-of-Helsinki/hauki-admin-ui/pull/402) renamed `data-test` props to `data-testid` props, but forgot 3 instances. This PR renames also those