### PR TITLE
fix: missing data-testid

### DIFF
--- a/e2e/tests/resource-page.spec.ts
+++ b/e2e/tests/resource-page.spec.ts
@@ -125,7 +125,7 @@ test.describe('Resource page', async () => {
     await page.getByRole('button', { name: 'Muokkaa juhlapyhiä' }).click();
 
     const holidayInput = page
-      .locator('input[data-test*="holiday-"]:not(:checked):not(:disabled)')
+      .locator('input[data-testid*="holiday-"]:not(:checked):not(:disabled)')
       .first();
     const holidayTestId = await holidayInput.getAttribute('data-testid');
 
@@ -146,7 +146,7 @@ test.describe('Resource page', async () => {
     await page.getByRole('button', { name: 'Muokkaa juhlapyhiä' }).click();
 
     const holidayInput = page
-      .locator('input[data-test*="holiday-"]:not(:checked):not(:disabled)')
+      .locator('input[data-testid*="holiday-"]:not(:checked):not(:disabled)')
       .first();
     const holidayTestId = await holidayInput.getAttribute('data-testid');
 


### PR DESCRIPTION
[PR](https://github.com/City-of-Helsinki/hauki-admin-ui/pull/402) renamed `data-test` props to `data-testid` props, but forgot 3 instances. This PR renames also those