### PR TITLE
fix: update Dockerfile to fix CVE-2026-42945

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN export APP_VERSION=$(yarn --silent app:version | tr -d '\n') && \
     envsubst '${APP_VERSION},${REACT_APP_RELEASE}' < /app/nginx.conf.template > /app/nginx.conf
 
 # =============================
-FROM registry.access.redhat.com/ubi9/nginx-120 as production
+FROM registry.access.redhat.com/ubi9/nginx-124 as production
 # =============================
 
 USER root


### PR DESCRIPTION
Updated the base image from ubi9/nginx-120
(nginx 1.20.1, the vulnerable version) to ubi9/nginx-124 (nginx 1.24.x) in the Dockerfile.

This resolves CVE-2026-42945 by replacing the
affected nginx package with a patched version shipped in the newer UBI9 nginx image.

More info: https://access.redhat.com/security/cve/cve-2026-42945

Refs: [HAUKI-805](https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-805)

[HAUKI-805]: https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ