### PR TITLE
feat: migrate from yarn to pnpm and adopt Helsinki base images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ report/
 .idea
 
 npm-debug.log*
+pnpm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 yarn.lock


### PR DESCRIPTION
Re-triggers release-please after #503 was squash-merged without a
  conventional commit prefix (and after #507's empty squash merge collapsed to a no-op on
   main).

  This PR adds `pnpm-debug.log*` to `.gitignore` — a small genuine change so the
  squash merge produces an actual commit on main, with a `feat:` title release-please
  can pick up.

  Once merged (squash), release-please will see the `feat:` commit and open a release
  PR bumping 1.14.4 → 1.15.0.

  Refs: HAUKI-785
  See: #503